### PR TITLE
Fix Supabase auth callback flow

### DIFF
--- a/app/auth/callback/route.js
+++ b/app/auth/callback/route.js
@@ -4,27 +4,61 @@ import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 
 export async function GET(req) {
+    const requestUrl = new URL(req.url)
+    const code = requestUrl.searchParams.get("code")
+    const nextPath = requestUrl.searchParams.get("next") ?? "/"
+
+    const cookieStore = cookies()
     const supabase = createServerClient(
         process.env.NEXT_PUBLIC_SUPABASE_URL,
         process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
         {
             cookies: {
-                getAll: () => cookies().getAll(),
-                setAll: (arr) => arr.forEach(({ name, value }) => cookies().set(name, value)),
+                getAll: () => cookieStore.getAll(),
+                setAll: (arr) => {
+                    arr.forEach(({ name, value, options }) => {
+                        cookieStore.set({ name, value, ...options })
+                    })
+                },
             },
         }
     )
 
-    // Ambil session user
-    const {
-        data: { user },
-    } = await supabase.auth.getUser()
-
-    if (!user) {
-        // kalau belum login, balik ke login
-        return NextResponse.redirect(new URL("/login", req.url))
+    if (code) {
+        const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code)
+        if (exchangeError) {
+            console.error("Failed to exchange OAuth code", exchangeError)
+            return NextResponse.redirect(new URL("/login?error=oauth", requestUrl.origin))
+        }
     }
 
-    // kalau udah login, arahkan ke /
-    return NextResponse.redirect(new URL("/", req.url))
+    const {
+        data: { user },
+        error: userError,
+    } = await supabase.auth.getUser()
+
+    if (!user || userError) {
+        return NextResponse.redirect(new URL("/login", requestUrl.origin))
+    }
+
+    const cookieHeader = cookieStore
+        .getAll()
+        .map(({ name, value }) => `${name}=${value}`)
+        .join("; ")
+
+    try {
+        const syncResponse = await fetch(new URL("/api/user/sync", requestUrl.origin), {
+            method: "POST",
+            headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+        })
+
+        if (!syncResponse.ok) {
+            const message = await syncResponse.text()
+            console.error("Failed to sync user profile", message)
+        }
+    } catch (error) {
+        console.error("Error syncing user profile", error)
+    }
+
+    return NextResponse.redirect(new URL(nextPath, requestUrl.origin))
 }

--- a/app/login/page.js
+++ b/app/login/page.js
@@ -21,11 +21,8 @@ export default function LoginPage() {
             return
         }
 
-        // 🔥 sinkronisasi user profile & metadata role
-        await fetch("/api/user/sync", { method: "POST" })
-
-        // redirect manual (biar gak stuck di login)
-        window.location.href = "/"
+        // arahkan ke callback supaya flow sinkronisasi konsisten dengan OAuth
+        window.location.href = "/auth/callback"
     }
 
     const handleGoogle = async () => {

--- a/middleware.js
+++ b/middleware.js
@@ -33,9 +33,10 @@ export async function middleware(req) {
     }
 
     const publicPaths = ["/login", "/register"]
+    const isAuthCallback = req.nextUrl.pathname === "/auth/callback"
 
     // 1️⃣ kalau BELUM login → tendang ke /login (kecuali di path /login & /register)
-    if (!user && !publicPaths.includes(req.nextUrl.pathname)) {
+    if (!user && !publicPaths.includes(req.nextUrl.pathname) && !isAuthCallback) {
         if (isDev) console.log("⚠️ Redirecting: Not logged in")
         const redirectUrl = req.nextUrl.clone()
         redirectUrl.pathname = "/login"


### PR DESCRIPTION
## Summary
- allow the Supabase OAuth callback route to bypass the middleware redirect
- exchange OAuth codes for server sessions and trigger user profile sync on the callback handler
- reroute password logins through the callback so metadata synchronization is centralized

## Testing
- not run (lint prompt requires manual configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e1ff592170832895270da29369e868