### PR TITLE
Add email column to user profile

### DIFF
--- a/app/api/user/sync/route.js
+++ b/app/api/user/sync/route.js
@@ -36,8 +36,8 @@ export async function POST() {
     // upsert ke Prisma
     await prisma.userProfile.upsert({
         where: { supabaseId: user.id },
-        update: { email: user.email, role: "user" },
-        create: { supabaseId: user.id, email: user.email, role: "user" },
+        update: { email: user.email ?? null, role: "user" },
+        create: { supabaseId: user.id, email: user.email ?? null, role: "user" },
     })
 
     console.log("✅ Synced user:", user.email)

--- a/prisma/migrations/20250606120000_add_userprofile_email/migration.sql
+++ b/prisma/migrations/20250606120000_add_userprofile_email/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "UserProfile" ADD COLUMN "email" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,7 @@ datasource db {
 model UserProfile {
   id          String   @id @default(uuid())
   supabaseId  String   @unique
+  email       String?
   role        String   @default("user")
   displayName String?
   createdAt   DateTime @default(now())


### PR DESCRIPTION
## Summary
- add an optional `email` field to the `UserProfile` Prisma model with a matching migration
- update the user sync API route to populate the new email column when upserting profiles

## Testing
- DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" DIRECT_URL="postgresql://postgres:postgres@localhost:5432/postgres" npx prisma migrate dev --name add-userprofile-email *(fails: database server not running in the container)*
- DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" DIRECT_URL="postgresql://postgres:postgres@localhost:5432/postgres" npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68e22d6e77f88328842620b25352841e