### PR TITLE
Add display name syncing to Prisma user profile

### DIFF
--- a/app/api/user/sync/route.js
+++ b/app/api/user/sync/route.js
@@ -33,11 +33,26 @@ export async function POST() {
         await supabase.auth.updateUser({ data: { role: "user" } })
     }
 
+    const displayName =
+        user.user_metadata?.full_name ??
+        user.user_metadata?.name ??
+        user.user_metadata?.display_name ??
+        null
+
     // upsert ke Prisma
     await prisma.userProfile.upsert({
         where: { supabaseId: user.id },
-        update: { email: user.email ?? null, role: "user" },
-        create: { supabaseId: user.id, email: user.email ?? null, role: "user" },
+        update: {
+            email: user.email ?? null,
+            role: "user",
+            displayName,
+        },
+        create: {
+            supabaseId: user.id,
+            email: user.email ?? null,
+            role: "user",
+            displayName,
+        },
     })
 
     console.log("✅ Synced user:", user.email)


### PR DESCRIPTION
## Summary
- derive a display name from Supabase user metadata during sync
- persist the resolved display name in the Prisma userProfile upsert

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e23dd4b6108328b5c5db6012f3194f