### PR TITLE
Allow remote avatars

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,9 @@
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: { serverActions: { bodySizeLimit: '2mb' } }
+  experimental: { serverActions: { bodySizeLimit: '2mb' } },
+  images: {
+    domains: ['lh3.googleusercontent.com']
+  }
 };
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js image loader to allow remote avatars from lh3.googleusercontent.com

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e24dd6ff54832884e0fe61da64f800