### PR TITLE
Allow unauthenticated access to landing page

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -42,7 +42,7 @@ export async function middleware(req) {
         console.log("🔍 Error:", error)
     }
 
-    const publicPaths = ["/login", "/register"]
+    const publicPaths = ["/", "/login", "/register"]
     const isAuthCallback = req.nextUrl.pathname === "/auth/callback"
 
     // 1️⃣ kalau BELUM login → tendang ke /login (kecuali di path /login & /register)


### PR DESCRIPTION
## Summary
- allow the middleware public path list to include the root landing page so logged-out visitors can view it

## Testing
- not run (manual verification required)

------
https://chatgpt.com/codex/tasks/task_e_68e28e21ad108328b67c82f9e567586f