### PR TITLE
Hide navbar on auth routes

### DIFF
--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -8,6 +8,8 @@ import Link from "next/link"
 import Image from "next/image"
 import { AlertCircle, LogOut, Menu, ShieldCheck, X } from "lucide-react"
 
+const AUTH_EXCLUDED_PATHS = ["/login", "/register"]
+
 const navigationLinks = [
     { href: "/feed", label: "Makanan Sehat" },
     { href: "/olahraga", label: "Olahraga" },
@@ -25,6 +27,13 @@ export default function Navbar() {
     )
     const router = useRouter()
     const pathname = usePathname()
+    const shouldHideNavbar = useMemo(() => {
+        if (!pathname) return false
+
+        if (AUTH_EXCLUDED_PATHS.includes(pathname)) return true
+
+        return pathname === "/auth" || pathname.startsWith("/auth/")
+    }, [pathname])
     const [userState, setUserState] = useState({
         loading: true,
         displayName: null,
@@ -177,6 +186,10 @@ export default function Navbar() {
         setIsMobileMenuOpen(false)
         router.push("/login")
         router.refresh()
+    }
+
+    if (shouldHideNavbar) {
+        return null
     }
 
     if (userState.loading) {


### PR DESCRIPTION
## Summary
- add a centralized list of authentication routes that should not render the navbar
- guard the navbar component so it bails early when the current pathname matches an auth route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e28fd5f4448328a03414ddb0d8345d