### PR TITLE
Refresh feed and olahraga pages with shared hero layout

### DIFF
--- a/app/feed/page.jsx
+++ b/app/feed/page.jsx
@@ -1,5 +1,8 @@
 "use client";
+import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { BookmarkPlus, ChefHat, Flame, Heart, Leaf, Sparkles, Timer, UtensilsCrossed } from "lucide-react";
+import PageHero from "@/components/ui/PageHero";
 import { rankRecipes } from "@/lib/reco";
 import { RECIPES } from "@/lib/data";
 
@@ -19,6 +22,24 @@ export default function Feed() {
   const [items, setItems] = useState(RECIPES);
   const [score, setScore] = useState({});
   const observer = useRef(null);
+
+  const topCategories = useMemo(() => {
+    const ranked = Object.entries(score || {})
+      .filter(([, value]) => value > 0)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([label, value]) => ({ label, value }));
+
+    if (ranked.length > 0) {
+      return ranked;
+    }
+
+    if (items.length > 0) {
+      return items[0].categories.slice(0, 3).map((label) => ({ label, value: 0 }));
+    }
+
+    return [];
+  }, [items, score]);
 
   useEffect(() => {
     async function init() {
@@ -67,68 +88,197 @@ export default function Feed() {
     setItems(rankRecipes(sres.score));
   }
 
+  function scrollToRecipes() {
+    document.getElementById("resep-harian")?.scrollIntoView({ behavior: "smooth" });
+  }
+
   return (
-    <div className="grid gap-4">
-      {items.map((r) => (
-        <article
-          key={r.id}
-          data-id={r.id}
-          className="recipe-card card overflow-hidden"
-        >
-          <img
-            src={r.image}
-            alt={r.name}
-            className="w-full h-60 object-cover"
-          />
-          <div className="p-4 grid gap-2">
-            <div className="flex items-center justify-between">
-              <h3 className="text-xl font-semibold">{r.name}</h3>
-              <span className="badge">≈ Rp{r.estCost.toLocaleString()}</span>
+    <div className="space-y-12">
+      <PageHero
+        eyebrow="Rekomendasi harian"
+        title={`Resep pilihan untuk ${user?.name ? user.name.split(" ")[0] : "kamu"}`}
+        description="Temukan menu hemat bernutrisi yang disusun dari preferensi kamu. Simpan favorit, beri like, dan lihat bagaimana skor personalmu makin presisi setiap kali kamu berinteraksi."
+        actions={
+          <>
+            <button onClick={scrollToRecipes} className="btn btn-primary">
+              Mulai jelajah resep
+            </button>
+            <Link
+              href="/feed"
+              className="btn btn-outline border-emerald-400/40 bg-slate-900/60 text-slate-200 hover:bg-slate-800"
+            >
+              Reset rekomendasi
+            </Link>
+          </>
+        }
+      >
+        <div className="rounded-3xl border border-emerald-500/30 bg-slate-900/70 p-6 shadow-inner shadow-emerald-500/20">
+          <div className="flex items-center gap-3">
+            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-200">
+              <ChefHat className="h-6 w-6" aria-hidden="true" />
             </div>
-            <p className="text-gray-300 text-sm">
-              Kategori: {r.categories.join(", ")}
-            </p>
-            <div className="grid grid-cols-2 gap-2 text-sm text-gray-300">
-              <div>
-                <p className="text-green-400">
-                  <b>Bahan:</b>
-                </p>
-                <ul className="list-disc list-inside">
-                  {r.ingredients.map((i) => (
-                    <li key={i}>{i}</li>
-                  ))}
-                </ul>
-              </div>
-              <div>
-                <p>
-                  <b>Tutorial:</b>
-                </p>
-                <p>{r.howto}</p>
-                <p className="mt-2">
-                  <b>Nutrisi:</b>{" "}
-                  {Object.entries(r.nutrients)
-                    .map(([k, v]) => `${k}:${v}`)
-                    .join(" | ")}
-                </p>
-              </div>
-            </div>
-            <div className="flex gap-2 pt-2">
-              <button
-                onClick={() => act(r.id, "like")}
-                className="btn btn-outline"
-              >
-                Like
-              </button>
-              <button
-                onClick={() => act(r.id, "save")}
-                className="btn btn-primary"
-              >
-                Save
-              </button>
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-emerald-200/80">Kategori favorit</p>
+              <p className="text-lg font-semibold text-white">{topCategories.map((c) => c.label).join(" • ") || "Menunggu data"}</p>
             </div>
           </div>
-        </article>
-      ))}
+          <ul className="mt-5 space-y-3 text-sm text-slate-300">
+            {topCategories.length > 0 ? (
+              topCategories.map(({ label, value }) => (
+                <li
+                  key={label}
+                  className="flex items-center justify-between rounded-2xl border border-slate-800/60 bg-slate-950/60 px-4 py-3"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-200">
+                      <Sparkles className="h-4 w-4" aria-hidden="true" />
+                    </div>
+                    <span className="font-medium text-slate-100">{label}</span>
+                  </div>
+                  <span className="text-xs uppercase tracking-[0.2em] text-emerald-200/70">
+                    Skor {value}
+                  </span>
+                </li>
+              ))
+            ) : (
+              <li className="rounded-2xl border border-slate-800/60 bg-slate-950/60 px-4 py-3 text-sm text-slate-300">
+                Interaksi kamu akan muncul di sini begitu kami mengenal selera kamu.
+              </li>
+            )}
+          </ul>
+          <div className="mt-6 flex items-center justify-between rounded-2xl border border-slate-800/60 bg-slate-900/70 px-4 py-3 text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+            <span className="flex items-center gap-2 text-emerald-200">
+              <Leaf className="h-4 w-4" aria-hidden="true" />
+              Masak hemat & sehat
+            </span>
+            <span>{items.length} resep aktif</span>
+          </div>
+        </div>
+      </PageHero>
+
+      <section id="resep-harian" className="space-y-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-1">
+            <h2 className="text-2xl font-semibold text-white">Pilihan resep untuk hari ini</h2>
+            <p className="text-sm text-slate-300">
+              Resep kami disusun agar pas buat dapur kos: bahan sederhana, waktu masak singkat, dan nutrisi tetap terjaga.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 rounded-full border border-slate-800/60 bg-slate-900/70 px-4 py-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+            <Timer className="h-4 w-4 text-emerald-200" aria-hidden="true" />
+            {""}
+            update realtime
+          </div>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          {items.map((r) => {
+            const preferenceScore = r.categories.reduce(
+              (total, category) => total + (score?.[category] || 0),
+              0
+            );
+
+            return (
+              <article
+                key={r.id}
+                data-id={r.id}
+                className="recipe-card group relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-950/60 shadow-xl shadow-slate-950/40 backdrop-blur-xl transition duration-300 hover:-translate-y-1 hover:border-emerald-400/40"
+              >
+                <div className="relative aspect-[4/3] overflow-hidden">
+                  <img
+                    src={r.image}
+                    alt={r.name}
+                    className="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-slate-950/80 via-slate-950/40 to-transparent" />
+                  <div className="absolute bottom-4 left-4 flex items-center gap-2">
+                    <span className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-100">
+                      <UtensilsCrossed className="h-4 w-4" aria-hidden="true" />
+                      {r.categories[0] || "Resep"}
+                    </span>
+                    <span className="rounded-full bg-slate-950/80 px-3 py-1 text-xs font-medium text-slate-200">
+                      Kecocokan {preferenceScore}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="space-y-6 p-6">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="space-y-2">
+                      <h3 className="text-2xl font-semibold text-white">{r.name}</h3>
+                      <p className="text-sm text-slate-300">
+                        {r.categories.join(" • ")} · {r.ingredients.length} bahan utama
+                      </p>
+                    </div>
+                    <span className="inline-flex items-center gap-2 rounded-2xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-100">
+                      <Flame className="h-4 w-4" aria-hidden="true" />≈ Rp{r.estCost.toLocaleString()}
+                    </span>
+                  </div>
+
+                  <div className="grid gap-6 sm:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+                    <div className="space-y-3">
+                      <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200">Bahan utama</p>
+                      <ul className="space-y-2 text-sm text-slate-200">
+                        {r.ingredients.map((i) => (
+                          <li key={i} className="flex items-center gap-2">
+                            <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+                            {i}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                    <div className="space-y-3">
+                      <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200">Langkah singkat</p>
+                      <p className="text-sm leading-relaxed text-slate-300">{r.howto}</p>
+                      <div className="flex flex-wrap gap-2">
+                        {Object.entries(r.nutrients).map(([key, value]) => (
+                          <span
+                            key={key}
+                            className="inline-flex items-center gap-1 rounded-full border border-slate-800/60 bg-slate-950/60 px-3 py-1 text-xs font-medium text-slate-200"
+                          >
+                            <Leaf className="h-3.5 w-3.5 text-emerald-200" aria-hidden="true" />
+                            {key}: {value}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="flex flex-col gap-4 border-t border-slate-800/60 pt-4 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+                      {r.categories.map((category) => (
+                        <span
+                          key={category}
+                          className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-3 py-1 text-[0.7rem] font-semibold text-emerald-100"
+                        >
+                          <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+                          {category}
+                        </span>
+                      ))}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <button
+                        onClick={() => act(r.id, "like")}
+                        className="btn btn-outline border-emerald-400/40 bg-slate-900/60 text-slate-100 hover:bg-emerald-500/10"
+                      >
+                        <Heart className="h-4 w-4" aria-hidden="true" />
+                        Suka
+                      </button>
+                      <button
+                        onClick={() => act(r.id, "save")}
+                        className="btn btn-primary"
+                      >
+                        <BookmarkPlus className="h-4 w-4" aria-hidden="true" />
+                        Simpan
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </section>
     </div>
   );
 }

--- a/app/olahraga/page.jsx
+++ b/app/olahraga/page.jsx
@@ -1,12 +1,66 @@
 "use client";
 import { useEffect, useState } from "react";
+import { Brain, Dumbbell, HeartPulse, MoonStar, Smile, Sparkles, SunMedium, Timer } from "lucide-react";
+import PageHero from "@/components/ui/PageHero";
+
+const MOOD_CHOICES = [
+  {
+    value: "🔥 Semangat",
+    label: "🔥 Semangat",
+    hint: "Siap gerak penuh energi",
+    icon: Sparkles,
+  },
+  {
+    value: "🙂 Biasa",
+    label: "🙂 Biasa",
+    hint: "Mood stabil, bisa olahraga santai",
+    icon: Smile,
+  },
+  {
+    value: "😴 Lelah",
+    label: "😴 Lelah",
+    hint: "Butuh pemulihan ringan",
+    icon: MoonStar,
+  },
+  {
+    value: "😕 Stres",
+    label: "😕 Stres",
+    hint: "Perlu release ketegangan",
+    icon: Brain,
+  },
+];
+
+const MOOD_SOLUTIONS = {
+  "🔥 Semangat": "Pertahankan energi positifmu hari ini!",
+  "🙂 Biasa": "Hari yang tenang, nikmati momen sederhana.",
+  "😴 Lelah": "Coba istirahat sejenak atau lakukan olahraga ringan.",
+  "😕 Stres": "Ambil napas dalam-dalam, coba olahraga singkat untuk relaksasi.",
+};
+
+const WORKOUT_SUGGESTIONS = {
+  "🔥 Semangat": {
+    name: "5 Menit Full Body",
+    moves: ["Jumping jack 60s", "Push-up 30s", "Plank 30s", "Squat 45s", "Stretch 1m"],
+  },
+  "🙂 Biasa": {
+    name: "Plank Ladder",
+    moves: ["Plank 20s", "Rest 10s", "Plank 30s", "Rest 10s", "Plank 40s"],
+  },
+  "😴 Lelah": {
+    name: "Stretching Kamar",
+    moves: ["Neck roll", "Shoulder stretch", "Hamstring stretch", "Hip opener"],
+  },
+  "😕 Stres": {
+    name: "Stretching Kamar",
+    moves: ["Neck roll", "Shoulder stretch", "Hamstring stretch", "Hip opener"],
+  },
+};
 
 export default function Olahraga() {
   const [workouts, setWorkouts] = useState([]);
   const [mood, setMood] = useState("");
   const [message, setMessage] = useState("");
   const [toast, setToast] = useState("");
-  const [activated, setActivated] = useState(false);
   const [recommendedWorkout, setRecommendedWorkout] = useState(null);
 
   useEffect(() => {
@@ -28,131 +82,181 @@ export default function Olahraga() {
       body: JSON.stringify({ mood }),
     });
 
-    const moodSolutions = {
-      "🔥 Semangat": "Pertahankan energi positifmu hari ini!",
-      "🙂 Biasa": "Hari yang tenang, nikmati momen sederhana.",
-      "😴 Lelah": "Coba istirahat sejenak atau lakukan olahraga ringan.",
-      "😕 Stres":
-        "Ambil napas dalam-dalam, coba olahraga singkat untuk relaksasi.",
-    };
-
-    const workoutSuggestions = {
-      "🔥 Semangat": {
-        name: "5 Menit Full Body",
-        moves: [
-          "Jumping jack 60s",
-          "Push-up 30s",
-          "Plank 30s",
-          "Squat 45s",
-          "Stretch 1m",
-        ],
-      },
-      "🙂 Biasa": {
-        name: "Plank Ladder",
-        moves: ["Plank 20s", "Rest 10s", "Plank 30s", "Rest 10s", "Plank 40s"],
-      },
-      "😴 Lelah": {
-        name: "Stretching Kamar",
-        moves: [
-          "Neck roll",
-          "Shoulder stretch",
-          "Hamstring stretch",
-          "Hip opener",
-        ],
-      },
-      "😕 Stres": {
-        name: "Stretching Kamar",
-        moves: [
-          "Neck roll",
-          "Shoulder stretch",
-          "Hamstring stretch",
-          "Hip opener",
-        ],
-      },
-    };
-
-    setMessage(moodSolutions[mood] || "");
-    setRecommendedWorkout(workoutSuggestions[mood] || null);
+    setMessage(MOOD_SOLUTIONS[mood] || "");
+    setRecommendedWorkout(WORKOUT_SUGGESTIONS[mood] || null);
     setMood("");
     setToast("Rekaman anda sudah di simpan !");
     setTimeout(() => setToast(""), 2500);
   }
 
   return (
-    <div className="grid gap-6">
-      {/* Bagian olahraga utama */}
-      <section className="card p-5">
-        <h1 className="text-2xl font-bold mb-3">Olahraga ringan di kost</h1>
-        <div className="grid gap-4">
-          {workouts.map((w) => (
-            <div key={w.id} className="border border-gray-700 rounded-xl p-4">
-              <h3 className="font-semibold">{w.name}</h3>
-              <ul className="list-disc list-inside text-gray-300">
-                {w.moves.map((m, i) => (
-                  <li key={i}>{m}</li>
+    <div className="space-y-12">
+      <PageHero
+        eyebrow="Ritme tubuh"
+        title="Olahraga ringan biar badan tetap fit di kos"
+        description="Tetap aktif meski ruang gerak terbatas. Pilih workout singkat, catat mood harian, dan dapatkan rekomendasi gerakan yang sesuai energimu."
+        actions={
+          <>
+            <button onClick={() => document.getElementById("workout-section")?.scrollIntoView({ behavior: "smooth" })} className="btn btn-primary">
+              Lihat daftar workout
+            </button>
+            <button
+              onClick={() => document.getElementById("mood-section")?.scrollIntoView({ behavior: "smooth" })}
+              className="btn btn-outline border-emerald-400/40 bg-slate-900/60 text-slate-200 hover:bg-slate-800"
+            >
+              Catat mood sekarang
+            </button>
+          </>
+        }
+      >
+        <div className="rounded-3xl border border-emerald-500/30 bg-slate-900/70 p-6 shadow-inner shadow-emerald-500/20">
+          <div className="flex items-start gap-3">
+            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-200">
+              <SunMedium className="h-6 w-6" aria-hidden="true" />
+            </div>
+            <div className="space-y-1">
+              <p className="text-xs uppercase tracking-[0.3em] text-emerald-200/80">Rutinitas sehat</p>
+              <p className="text-lg font-semibold text-white">Durasi pendek, efek panjang</p>
+              <p className="text-sm text-slate-300">
+                Sesi 5-10 menit sudah cukup buat jaga stamina dan fokus belajar.
+              </p>
+            </div>
+          </div>
+          <dl className="mt-6 grid gap-4 sm:grid-cols-3">
+            <div className="rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4">
+              <dt className="text-xs uppercase tracking-[0.3em] text-slate-400">Gerakan</dt>
+              <dd className="mt-2 text-lg font-semibold text-white">{workouts.length} paket</dd>
+            </div>
+            <div className="rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4">
+              <dt className="text-xs uppercase tracking-[0.3em] text-slate-400">Waktu</dt>
+              <dd className="mt-2 flex items-center gap-2 text-lg font-semibold text-white">
+                <Timer className="h-4 w-4 text-emerald-200" aria-hidden="true" />5-10 mnt
+              </dd>
+            </div>
+            <div className="rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4">
+              <dt className="text-xs uppercase tracking-[0.3em] text-slate-400">Fokus</dt>
+              <dd className="mt-2 text-lg font-semibold text-white">Mood & energi</dd>
+            </div>
+          </dl>
+        </div>
+      </PageHero>
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
+        <section id="workout-section" className="card space-y-6">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-3">
+              <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-200">
+                <Dumbbell className="h-6 w-6" aria-hidden="true" />
+              </div>
+              <div className="space-y-1">
+                <h2 className="text-xl font-semibold text-white">Pilihan workout singkat</h2>
+                <p className="text-sm text-slate-300">
+                  Setiap paket bisa kamu lakukan di kamar kos tanpa alat tambahan.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {workouts.map((w) => (
+              <div
+                key={w.id}
+                className="group relative overflow-hidden rounded-2xl border border-slate-800/60 bg-slate-950/60 p-5 transition duration-300 hover:-translate-y-1 hover:border-emerald-400/40"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <h3 className="text-lg font-semibold text-white">{w.name}</h3>
+                    <p className="text-xs uppercase tracking-[0.3em] text-slate-400">{w.moves.length} langkah</p>
+                  </div>
+                  <span className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-100">
+                    <HeartPulse className="h-4 w-4" aria-hidden="true" />Fokus tubuh
+                  </span>
+                </div>
+                <ul className="mt-4 space-y-2 text-sm text-slate-300">
+                  {w.moves.map((m, i) => (
+                    <li key={i} className="flex items-center gap-2">
+                      <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+                      {m}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section id="mood-section" className="card relative space-y-6">
+          <div className="flex items-start gap-3">
+            <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-200">
+              <Brain className="h-6 w-6" aria-hidden="true" />
+            </div>
+            <div className="space-y-1">
+              <h2 className="text-xl font-semibold text-white">Mood tracker</h2>
+              <p className="text-sm text-slate-300">
+                Tandai perasaanmu lalu simpan, supaya rekomendasi olahraga makin relevan.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            {MOOD_CHOICES.map(({ value, label, hint, icon: Icon }) => (
+              <button
+                key={value}
+                onClick={() => {
+                  setMood(value);
+                }}
+                className={`rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4 text-left transition duration-200 hover:border-emerald-400/40 hover:bg-slate-900/60 ${
+                  mood === value
+                    ? "border-emerald-400/60 bg-emerald-500/10 text-white shadow-inner shadow-emerald-500/30"
+                    : "text-slate-100"
+                }`}
+              >
+                <div className="flex items-start gap-3">
+                  <div className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-200">
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </div>
+                  <div>
+                    <p className="font-semibold">{label}</p>
+                    <p className="text-xs text-slate-300">{hint}</p>
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+
+          <button onClick={submitMood} className="btn btn-primary w-full sm:w-auto">
+            Simpan mood
+          </button>
+
+          {message && (
+            <div className="space-y-3 rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-4 text-sm text-emerald-100 animate-fade-in">
+              {message}
+            </div>
+          )}
+
+          {recommendedWorkout && (
+            <div className="space-y-3 rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4">
+              <div className="flex items-center gap-2 text-sm font-semibold text-white">
+                <HeartPulse className="h-4 w-4 text-emerald-200" aria-hidden="true" />
+                {recommendedWorkout.name}
+              </div>
+              <ul className="space-y-2 text-sm text-slate-300">
+                {recommendedWorkout.moves.map((m, i) => (
+                  <li key={i} className="flex items-center gap-2">
+                    <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+                    {m}
+                  </li>
                 ))}
               </ul>
             </div>
-          ))}
-        </div>
-      </section>
+          )}
 
-      {/* Bagian Mood Tracker */}
-      <section className="card p-5 relative">
-        <h2 className="text-xl font-semibold mb-2">Mood Tracker</h2>
-        <div className="flex gap-3 flex-wrap">
-          {["🔥 Semangat", "🙂 Biasa", "😴 Lelah", "😕 Stres"].map((x) => (
-            <button
-              key={x}
-              onClick={() => {
-                setMood(x);
-                setActivated(true);
-              }}
-              className={`badge transform transition-all duration-200 active:scale-95 ${
-                mood === x
-                  ? "bg-emerald-700 text-white border border-emerald-500 shadow-lg"
-                  : activated
-                  ? "bg-gray-700 hover:bg-gray-600"
-                  : "bg-gray-700"
-              }`}
-            >
-              {x}
-            </button>
-          ))}
-        </div>
-        <button
-          onClick={submitMood}
-          className="btn btn-primary mt-4 transform transition active:scale-95"
-        >
-          Simpan Mood
-        </button>
-
-        {/* Pesan solusi */}
-        {message && (
-          <div className="mt-3 p-3 rounded bg-emerald-900 text-white animate-fade-in">
-            {message}
-          </div>
-        )}
-
-        {/* Rekomendasi olahraga */}
-        {recommendedWorkout && (
-          <div className="mt-4 border border-gray-700 rounded-xl p-4 bg-gray-800/70">
-            <h3 className="font-semibold">{recommendedWorkout.name}</h3>
-            <ul className="list-disc list-inside text-gray-300">
-              {recommendedWorkout.moves.map((m, i) => (
-                <li key={i}>{m}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        {/* Toast */}
-        {toast && (
-          <div className="absolute top-2 right-2 bg-emerald-600 text-white px-4 py-2 rounded shadow-lg animate-fade-in">
-            {toast}
-          </div>
-        )}
-      </section>
+          {toast && (
+            <div className="animate-toast-in absolute -top-4 right-4 rounded-2xl border border-emerald-400/40 bg-emerald-500/90 px-4 py-2 text-sm font-semibold text-white shadow-lg">
+              {toast}
+            </div>
+          )}
+        </section>
+      </div>
     </div>
   );
 }

--- a/components/ui/PageHero.jsx
+++ b/components/ui/PageHero.jsx
@@ -1,0 +1,42 @@
+export default function PageHero({
+  eyebrow,
+  title,
+  description,
+  actions,
+  children,
+  align = "center",
+}) {
+  return (
+    <section className="relative overflow-hidden rounded-[2.5rem] border border-slate-800/70 bg-slate-950/70 p-8 shadow-2xl shadow-emerald-500/10 sm:p-12">
+      <div className="pointer-events-none absolute -left-24 top-0 h-56 w-56 rounded-full bg-emerald-500/20 blur-3xl" />
+      <div className="pointer-events-none absolute right-0 bottom-0 h-64 w-64 rounded-full bg-indigo-500/20 blur-3xl" />
+      <div className="relative grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.9fr)] lg:items-center">
+        <div className="space-y-6">
+          {eyebrow ? (
+            <span className="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-emerald-200">
+              {eyebrow}
+            </span>
+          ) : null}
+          <div className="space-y-4">
+            <h1
+              className={`text-3xl font-semibold tracking-tight text-white sm:text-4xl lg:text-5xl ${
+                align === "left" ? "text-left" : ""
+              }`}
+            >
+              {title}
+            </h1>
+            {description ? (
+              <p className="text-base leading-relaxed text-slate-300 sm:text-lg">
+                {description}
+              </p>
+            ) : null}
+          </div>
+          {actions ? (
+            <div className="flex flex-wrap gap-3">{actions}</div>
+          ) : null}
+        </div>
+        {children ? <div className="relative">{children}</div> : null}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce a reusable PageHero layout component that mirrors the landing hero styling
- restyle the feed page with a hero banner, richer recipe cards, and interaction-driven highlights
- reorganize the olahraga page into split cards with iconography, mood guidance, and workout emphasis

## Testing
- npm run lint *(fails: prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e28fd9b1288328a5b94948e12bc2d6