### PR TITLE
Add authenticated home route and fix login redirects

### DIFF
--- a/app/auth/callback/route.js
+++ b/app/auth/callback/route.js
@@ -6,7 +6,7 @@ import { cookies } from "next/headers"
 export async function GET(req) {
     const requestUrl = new URL(req.url)
     const code = requestUrl.searchParams.get("code")
-    const nextPath = requestUrl.searchParams.get("next") ?? "/"
+    const nextPath = requestUrl.searchParams.get("next") ?? "/home"
 
     const cookieStore = cookies()
     const supabase = createServerClient(

--- a/app/home/page.jsx
+++ b/app/home/page.jsx
@@ -1,0 +1,27 @@
+import AuthenticatedHome from "@/components/home/AuthenticatedHome"
+import { createClient } from "@/lib/supabase/server"
+import { redirect } from "next/navigation"
+
+export default async function HomePage() {
+  let supabase
+
+  try {
+    supabase = createClient()
+  } catch (error) {
+    console.error("Supabase client init failed:", error)
+    redirect("/")
+  }
+
+  try {
+    const { data, error } = await supabase.auth.getUser()
+
+    if (error || !data?.user) {
+      redirect("/")
+    }
+
+    return <AuthenticatedHome />
+  } catch (error) {
+    console.error("Supabase session check failed:", error)
+    redirect("/")
+  }
+}

--- a/app/login/page.js
+++ b/app/login/page.js
@@ -12,13 +12,13 @@ export default function LoginPage() {
     const [error, setError] = useState("")
     const searchParams = useSearchParams()
     const nextParam = useMemo(() => {
-        const value = searchParams?.get("next") ?? "/"
-        return value.startsWith("/") ? value : "/"
+        const value = searchParams?.get("next") ?? "/home"
+        return value.startsWith("/") ? value : "/home"
     }, [searchParams])
 
     const buildCallbackUrl = () => {
         const basePath = "/auth/callback"
-        if (!nextParam || nextParam === "/") return basePath
+        if (!nextParam || nextParam === "/home") return basePath
         const url = new URL(basePath, window.location.origin)
         url.searchParams.set("next", nextParam)
         return `${url.pathname}${url.search}`

--- a/app/register/page.js
+++ b/app/register/page.js
@@ -15,14 +15,14 @@ export default function RegisterPage() {
     const [message, setMessage] = useState("")
     const searchParams = useSearchParams()
     const nextParam = useMemo(() => {
-        const value = searchParams?.get("next") ?? "/"
-        return value.startsWith("/") ? value : "/"
+        const value = searchParams?.get("next") ?? "/home"
+        return value.startsWith("/") ? value : "/home"
     }, [searchParams])
 
     const buildCallbackUrl = () => {
         const basePath = "/auth/callback"
         const url = new URL(basePath, window.location.origin)
-        if (nextParam && nextParam !== "/") {
+        if (nextParam && nextParam !== "/home") {
             url.searchParams.set("next", nextParam)
         }
         return `${url.pathname}${url.search}`

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -15,6 +15,8 @@ const navigationLinks = [
     { href: "/onboarding", label: "Pilih Makanan" },
 ]
 
+const hiddenRoutes = ["/login", "/register", "/auth/callback"]
+
 export default function Navbar() {
     const isSupabaseConfigured = Boolean(
         process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
@@ -179,6 +181,10 @@ export default function Navbar() {
         router.refresh()
     }
 
+    if (hiddenRoutes.some((route) => pathname === route || pathname.startsWith(`${route}/`))) {
+        return null
+    }
+
     if (userState.loading) {
         return null
     }
@@ -194,7 +200,7 @@ export default function Navbar() {
                 <nav className="flex h-20 items-center justify-between gap-6">
                     {/* Logo */}
                     <div className="flex flex-1 items-center gap-4">
-                        <Link href="/" className="flex items-center gap-3">
+                        <Link href="/home" className="flex items-center gap-3">
                             <Image
                                 src="/Logo.png"
                                 alt="KoSurvive Logo"

--- a/middleware.js
+++ b/middleware.js
@@ -42,7 +42,8 @@ export async function middleware(req) {
         console.log("🔍 Error:", error)
     }
 
-    const publicPaths = ["/login", "/register"]
+    const publicPaths = ["/", "/login", "/register"]
+    const authOnlyPaths = ["/login", "/register"]
     const isAuthCallback = req.nextUrl.pathname === "/auth/callback"
 
     // 1️⃣ kalau BELUM login → tendang ke /login (kecuali di path /login & /register)
@@ -53,11 +54,11 @@ export async function middleware(req) {
         return NextResponse.redirect(redirectUrl)
     }
 
-    // 2️⃣ kalau SUDAH login → jangan bisa buka /login atau /register
-    if (user && publicPaths.includes(req.nextUrl.pathname)) {
+    // 2️⃣ kalau SUDAH login → jangan bisa buka halaman auth atau landing
+    if (user && (authOnlyPaths.includes(req.nextUrl.pathname) || req.nextUrl.pathname === "/")) {
         if (isDev) console.log("⚠️ Redirecting: Already logged in")
         const redirectUrl = req.nextUrl.clone()
-        redirectUrl.pathname = "/" // atau "/app-user" sesuai kebutuhan lo
+        redirectUrl.pathname = "/home"
         return NextResponse.redirect(redirectUrl)
     }
 
@@ -69,7 +70,7 @@ export async function middleware(req) {
         if (req.nextUrl.pathname.startsWith("/admin") && role !== "admin") {
             if (isDev) console.log("⛔ Access denied: not admin")
             const redirectUrl = req.nextUrl.clone()
-            redirectUrl.pathname = "/"
+            redirectUrl.pathname = "/home"
             return NextResponse.redirect(redirectUrl)
         }
     }


### PR DESCRIPTION
## Summary
- add a dedicated /home route that serves the authenticated dashboard and redirects visitors without a session back to the landing page
- update auth callback, login/register forms, and middleware to default authenticated users to /home and avoid redirect loops when hitting the landing page
- hide the navbar on auth routes and point the logo link to /home so the login screen no longer flashes the protected navigation

## Testing
- not run (npm run lint prompts for an interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_68e28e21ad108328b67c82f9e567586f