### PR TITLE
Add async loader tracking helper and wrap client fetches

### DIFF
--- a/app/onboarding/page.jsx
+++ b/app/onboarding/page.jsx
@@ -1,23 +1,27 @@
 "use client";
 import { useState } from "react";
 import { CATEGORIES } from "@/lib/data";
+import { useAsyncLoader } from "@/components/RouteLoader";
 
 export default function Onboarding() {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [prefs, setPrefs] = useState([]);
   const [open, setOpen] = useState(false);
+  const { track } = useAsyncLoader();
 
   const toggle = (c) => {
     setPrefs((p) => (p.includes(c) ? p.filter((x) => x !== c) : [...p, c]));
   };
 
   async function save() {
-    const res = await fetch("/api/user", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name, email, prefs }),
-    });
+    const res = await track(() =>
+      fetch("/api/user", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email, prefs }),
+      })
+    );
     if (res.ok) window.location.href = "/feed";
   }
 


### PR DESCRIPTION
## Summary
- add an async pending counter to the route loader and expose a `useAsyncLoader` helper for tracking promises
- wrap feed page data fetching in the new tracker so the overlay stays visible until requests settle
- apply the tracker to the onboarding save action to keep UX consistent during network calls

## Testing
- npm run lint *(fails: Next.js ESLint configuration prompt requires interactive choice)*

------
https://chatgpt.com/codex/tasks/task_e_68e2a612c7e083289eed00b51c1fc003