### PR TITLE
Use async loader for Belajar courses

### DIFF
--- a/app/belajar/page.jsx
+++ b/app/belajar/page.jsx
@@ -1,18 +1,24 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
+import { useAsyncLoader } from "@/components/RouteLoader";
 
 export default function Belajar() {
   const [items, setItems] = useState([]);
   const [q, setQ] = useState("");
   const [watched, setWatched] = useState({});
   const [toast, setToast] = useState(false); // ✅ state untuk notifikasi
+  const { track } = useAsyncLoader();
 
   // ✅ Ambil data dari API
   useEffect(() => {
-    fetch("/api/courses")
-      .then((r) => r.json())
-      .then(setItems);
-  }, []);
+    async function loadCourses() {
+      const data = await track(() =>
+        fetch("/api/courses").then((r) => r.json())
+      );
+      setItems(data);
+    }
+    loadCourses();
+  }, [track]);
 
   // ✅ Load progress dari localStorage saat pertama kali
   useEffect(() => {


### PR DESCRIPTION
## Summary
- import the route async loader utilities on the Belajar page
- wrap the initial course fetch in the tracked loader to surface loading state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e327bb5b5883288d592418d7cd8b39