### PR TITLE
Track workout fetch with route loader overlay

### DIFF
--- a/app/tambah-aktivitas/page.jsx
+++ b/app/tambah-aktivitas/page.jsx
@@ -1,18 +1,35 @@
 "use client";
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+import { useAsyncLoader } from "@/components/RouteLoader";
 
 export default function TambahAktivitas() {
   const [selectedDate, setSelectedDate] = useState("");
   const [selectedWorkout, setSelectedWorkout] = useState("");
   const [workouts, setWorkouts] = useState([]);
   const router = useRouter();
+  const { track } = useAsyncLoader();
 
   useEffect(() => {
-    fetch("/api/workouts")
-      .then((r) => r.json())
-      .then((data) => setWorkouts(data));
-  }, []);
+    let isCancelled = false;
+
+    async function loadWorkouts() {
+      try {
+        const data = await track(() => fetch("/api/workouts").then((r) => r.json()));
+        if (!isCancelled) {
+          setWorkouts(data);
+        }
+      } catch (error) {
+        console.error("Failed to load workouts", error);
+      }
+    }
+
+    loadWorkouts();
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [track]);
 
   useEffect(() => {
     const d = localStorage.getItem("selectedDate");


### PR DESCRIPTION
## Summary
- import and use the async route loader on the tambah aktivitas page
- track the workouts fetch before updating local state so the overlay reflects the request lifecycle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e327bd54bc832897f820e8c6088365