### PR TITLE
Add scroll margins to anchored sections

### DIFF
--- a/app/feed/page.jsx
+++ b/app/feed/page.jsx
@@ -160,7 +160,7 @@ export default function Feed() {
         </div>
       </PageHero>
 
-      <section id="resep-harian" className="space-y-6">
+      <section id="resep-harian" className="space-y-6 scroll-mt-28">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div className="space-y-1">
             <h2 className="text-2xl font-semibold text-white">Pilihan resep untuk hari ini</h2>

--- a/app/olahraga/page.jsx
+++ b/app/olahraga/page.jsx
@@ -148,7 +148,7 @@ export default function Olahraga() {
       </PageHero>
 
       <div className="grid gap-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
-        <section id="workout-section" className="card space-y-6">
+        <section id="workout-section" className="card space-y-6 scroll-mt-28">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start gap-3">
               <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-200">
@@ -190,7 +190,7 @@ export default function Olahraga() {
           </div>
         </section>
 
-        <section id="mood-section" className="card relative space-y-6">
+        <section id="mood-section" className="card relative space-y-6 scroll-mt-28">
           <div className="flex items-start gap-3">
             <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/10 text-emerald-200">
               <Brain className="h-6 w-6" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- add scroll margin utility to workout and mood sections on the olahraga page
- apply the same scroll margin to the daily recipe section on the feed page to avoid the header overlap

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e335a2d4ec8328bbaed56d9ed93727