### PR TITLE
Handle Supabase config gaps and wrap auth pages in suspense

### DIFF
--- a/app/api/auth/callback/route.js
+++ b/app/api/auth/callback/route.js
@@ -2,17 +2,23 @@ import { NextResponse } from "next/server"
 import { cookies } from "next/headers"
 import { createServerClient } from "@supabase/ssr"
 
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
 export async function GET(request) {
-    const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-        {
-            cookies: {
-                getAll: () => cookies().getAll(),
-                setAll: (arr) => arr.forEach(({ name, value }) => cookies().set(name, value)),
-            },
-        }
-    )
+    if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+        console.error("Supabase belum dikonfigurasi. NEXT_PUBLIC_SUPABASE_URL dan NEXT_PUBLIC_SUPABASE_ANON_KEY wajib diisi.")
+        return NextResponse.redirect(new URL("/login", request.url))
+    }
+
+    const cookieStore = cookies()
+
+    const supabase = createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+        cookies: {
+            getAll: () => cookieStore.getAll(),
+            setAll: (arr) => arr.forEach(({ name, value, options }) => cookieStore.set({ name, value, ...options })),
+        },
+    })
 
     // ✅ Refresh session setelah redirect dari Google
     const {
@@ -29,5 +35,7 @@ export async function GET(request) {
     await fetch(`${request.nextUrl.origin}/api/user/sync`, { method: "POST" })
 
     // ✅ Redirect ke halaman utama
-    return NextResponse.redirect(new URL("/", request.url))
+    const nextParam = request.nextUrl.searchParams.get("next")
+    const target = nextParam && nextParam.startsWith("/") ? nextParam : "/"
+    return NextResponse.redirect(new URL(target, request.url))
 }

--- a/app/auth-check/page.js
+++ b/app/auth-check/page.js
@@ -1,12 +1,30 @@
 import { createClient } from "@/lib/supabase/server"
 
+export const dynamic = "force-dynamic"
+
 export default async function AuthCheckPage() {
-    const supabase = createClient()
+    let supabase
 
-    // Lebih aman pakai getUser
-    const { data: { user }, error } = await supabase.auth.getUser()
+    try {
+        supabase = createClient()
+    } catch (error) {
+        console.error("Supabase client init failed:", error)
+        return (
+            <pre>{JSON.stringify({ user: null, error: error.message }, null, 2)}</pre>
+        )
+    }
 
-    return (
-        <pre>{JSON.stringify({ user, error }, null, 2)}</pre>
-    )
+    try {
+        const {
+            data: { user },
+            error,
+        } = await supabase.auth.getUser()
+
+        return <pre>{JSON.stringify({ user, error }, null, 2)}</pre>
+    } catch (error) {
+        console.error("Supabase session check failed:", error)
+        return (
+            <pre>{JSON.stringify({ user: null, error: error.message }, null, 2)}</pre>
+        )
+    }
 }

--- a/app/home/page.jsx
+++ b/app/home/page.jsx
@@ -2,6 +2,8 @@ import AuthenticatedHome from "@/components/home/AuthenticatedHome"
 import { createClient } from "@/lib/supabase/server"
 import { redirect } from "next/navigation"
 
+export const dynamic = "force-dynamic"
+
 export default async function HomePage() {
   let supabase
 

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react"
 import "./globals.css"
 import ClientNavbar from "@/components/ClientNavbar"
 import RouteLoaderProvider from "@/components/RouteLoader"
@@ -11,24 +12,26 @@ export default function RootLayout({ children }) {
   return (
     <html lang="id">
       <body className="min-h-screen bg-slate-950 text-slate-100 antialiased">
-        <RouteLoaderProvider>
-          <div className="relative flex min-h-screen flex-col overflow-hidden">
-            <div className="pointer-events-none absolute inset-0 -z-10 opacity-90">
-              <div className="absolute -left-1/2 top-[-25%] h-[420px] w-[720px] rounded-full bg-emerald-500/20 blur-3xl" />
-              <div className="absolute right-[-30%] top-[15%] h-[520px] w-[520px] rounded-full bg-indigo-500/10 blur-3xl" />
-              <div className="absolute bottom-[-20%] left-[10%] h-[320px] w-[520px] rounded-full bg-cyan-500/10 blur-3xl" />
-              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.08),_transparent_60%)]" />
-            </div>
+        <Suspense fallback={null}>
+          <RouteLoaderProvider>
+            <div className="relative flex min-h-screen flex-col overflow-hidden">
+              <div className="pointer-events-none absolute inset-0 -z-10 opacity-90">
+                <div className="absolute -left-1/2 top-[-25%] h-[420px] w-[720px] rounded-full bg-emerald-500/20 blur-3xl" />
+                <div className="absolute right-[-30%] top-[15%] h-[520px] w-[520px] rounded-full bg-indigo-500/10 blur-3xl" />
+                <div className="absolute bottom-[-20%] left-[10%] h-[320px] w-[520px] rounded-full bg-cyan-500/10 blur-3xl" />
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(148,163,184,0.08),_transparent_60%)]" />
+              </div>
 
-            <ClientNavbar />
-            <main className="relative flex-1 px-4 py-12 sm:px-6 lg:px-12">
-              <div className="mx-auto w-full max-w-6xl space-y-16">{children}</div>
-            </main>
-            <footer className="relative border-t border-slate-800/70 bg-slate-950/80 py-10 text-center text-sm text-slate-400">
-              © {new Date().getFullYear()} DevSpectra - KoSurvive.
-            </footer>
-          </div>
-        </RouteLoaderProvider>
+              <ClientNavbar />
+              <main className="relative flex-1 px-4 py-12 sm:px-6 lg:px-12">
+                <div className="mx-auto w-full max-w-6xl space-y-16">{children}</div>
+              </main>
+              <footer className="relative border-t border-slate-800/70 bg-slate-950/80 py-10 text-center text-sm text-slate-400">
+                © {new Date().getFullYear()} DevSpectra - KoSurvive.
+              </footer>
+            </div>
+          </RouteLoaderProvider>
+        </Suspense>
       </body>
     </html>
   )

--- a/app/login/LoginPageContent.jsx
+++ b/app/login/LoginPageContent.jsx
@@ -5,9 +5,27 @@ import { useRouter, useSearchParams } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
 import { useRouteLoader } from "@/components/RouteLoader"
 
-export default function LoginPage() {
+export function LoadingState() {
+    return (
+        <div className="flex items-center justify-center min-h-screen">
+            <div className="flex flex-col items-center gap-3 text-slate-300">
+                <span className="inline-flex h-10 w-10 animate-spin rounded-full border-4 border-indigo-400 border-t-transparent" />
+                <p className="text-sm font-medium">Menyiapkan halaman masuk...</p>
+            </div>
+        </div>
+    )
+}
+
+export default function LoginPageContent() {
     const router = useRouter()
-    const supabase = createClient()
+    const { client: supabase, error: configError } = useMemo(() => {
+        try {
+            return { client: createClient(), error: null }
+        } catch (error) {
+            console.error("Supabase client init failed:", error)
+            return { client: null, error }
+        }
+    }, [])
     const [email, setEmail] = useState("")
     const [password, setPassword] = useState("")
     const [loading, setLoading] = useState(false)
@@ -18,6 +36,21 @@ export default function LoginPage() {
         const value = searchParams?.get("next") ?? "/home"
         return value.startsWith("/") ? value : "/home"
     }, [searchParams])
+
+    if (!supabase) {
+        const message = configError?.message ?? "Supabase belum dikonfigurasi."
+        return (
+            <div className="flex min-h-screen items-center justify-center px-6 text-center text-sm text-rose-200">
+                <div className="max-w-md space-y-2 rounded-2xl border border-rose-400/30 bg-rose-950/40 p-6 backdrop-blur">
+                    <p className="text-base font-semibold text-rose-100">Konfigurasi auth belum lengkap</p>
+                    <p>{message}</p>
+                    <p className="text-xs text-rose-300/80">
+                        Tambahkan NEXT_PUBLIC_SUPABASE_URL dan NEXT_PUBLIC_SUPABASE_ANON_KEY ke environment sebelum mencoba login.
+                    </p>
+                </div>
+            </div>
+        )
+    }
 
     const buildCallbackUrl = () => {
         const basePath = "/auth/callback"
@@ -42,7 +75,6 @@ export default function LoginPage() {
                 return
             }
 
-            // arahkan ke callback supaya flow sinkronisasi konsisten dengan OAuth
             router.replace(buildCallbackUrl())
         } catch (err) {
             console.error(err)
@@ -74,18 +106,14 @@ export default function LoginPage() {
         }
     }
 
-
     return (
         <div className="flex items-center justify-center min-h-screen">
             <div className="w-full max-w-md bg-[rgba(30,30,46,0.7)] backdrop-blur-xl rounded-2xl shadow-xl p-8">
-
-                {/* Brand */}
                 <div className="text-center mb-8">
                     <h1 className="text-2xl font-bold text-white">Masuk</h1>
                     <p className="text-sm text-gray-400">Akses akun Anda</p>
                 </div>
 
-                {/* Form */}
                 <form onSubmit={handleLogin} className="space-y-4">
                     <div>
                         <label className="text-sm text-gray-300">Email</label>
@@ -126,14 +154,12 @@ export default function LoginPage() {
                     </button>
                 </form>
 
-                {/* Divider */}
                 <div className="flex items-center gap-2 my-6 text-gray-400 text-sm">
                     <div className="flex-grow h-px bg-white/10" />
                     <span>atau</span>
                     <div className="flex-grow h-px bg-white/10" />
                 </div>
 
-                {/* Google login */}
                 <button
                     onClick={handleGoogle}
                     disabled={loading}
@@ -157,7 +183,6 @@ export default function LoginPage() {
                     )}
                 </button>
 
-                {/* Link ke register */}
                 <p className="mt-6 text-center text-sm text-gray-400">
                     Belum punya akun?{" "}
                     <a href="/register" className="text-indigo-400 hover:underline">
@@ -168,3 +193,4 @@ export default function LoginPage() {
         </div>
     )
 }
+

--- a/app/login/page.jsx
+++ b/app/login/page.jsx
@@ -1,0 +1,12 @@
+import { Suspense } from "react"
+import LoginPageContent, { LoadingState } from "./LoginPageContent"
+
+export const dynamic = "force-dynamic"
+
+export default function LoginPage() {
+    return (
+        <Suspense fallback={<LoadingState />}>
+            <LoginPageContent />
+        </Suspense>
+    )
+}

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -2,6 +2,8 @@ import AuthenticatedHome from "@/components/home/AuthenticatedHome"
 import LandingPage from "@/components/home/LandingPage"
 import { createClient } from "@/lib/supabase/server"
 
+export const dynamic = "force-dynamic"
+
 export default async function Home() {
   let supabase
 

--- a/app/register/RegisterPageContent.jsx
+++ b/app/register/RegisterPageContent.jsx
@@ -4,8 +4,26 @@ import { useMemo, useState } from "react"
 import { useSearchParams } from "next/navigation"
 import { createClient } from "@/lib/supabase/client"
 
-export default function RegisterPage() {
-    const supabase = createClient()
+export function LoadingState() {
+    return (
+        <div className="flex items-center justify-center min-h-screen">
+            <div className="flex flex-col items-center gap-3 text-slate-300">
+                <span className="inline-flex h-10 w-10 animate-spin rounded-full border-4 border-indigo-400 border-t-transparent" />
+                <p className="text-sm font-medium">Menyiapkan halaman daftar...</p>
+            </div>
+        </div>
+    )
+}
+
+export default function RegisterPageContent() {
+    const { client: supabase, error: configError } = useMemo(() => {
+        try {
+            return { client: createClient(), error: null }
+        } catch (error) {
+            console.error("Supabase client init failed:", error)
+            return { client: null, error }
+        }
+    }, [])
     const [email, setEmail] = useState("")
     const [password, setPassword] = useState("")
     const [confirmPassword, setConfirmPassword] = useState("")
@@ -18,6 +36,21 @@ export default function RegisterPage() {
         const value = searchParams?.get("next") ?? "/home"
         return value.startsWith("/") ? value : "/home"
     }, [searchParams])
+
+    if (!supabase) {
+        const message = configError?.message ?? "Supabase belum dikonfigurasi."
+        return (
+            <div className="flex min-h-screen items-center justify-center px-6 text-center text-sm text-rose-200">
+                <div className="max-w-md space-y-2 rounded-2xl border border-rose-400/30 bg-rose-950/40 p-6 backdrop-blur">
+                    <p className="text-base font-semibold text-rose-100">Konfigurasi auth belum lengkap</p>
+                    <p>{message}</p>
+                    <p className="text-xs text-rose-300/80">
+                        Tambahkan NEXT_PUBLIC_SUPABASE_URL dan NEXT_PUBLIC_SUPABASE_ANON_KEY ke environment sebelum mencoba daftar.
+                    </p>
+                </div>
+            </div>
+        )
+    }
 
     const buildCallbackUrl = () => {
         const basePath = "/auth/callback"
@@ -87,14 +120,11 @@ export default function RegisterPage() {
     return (
         <div className="flex items-center justify-center min-h-screen">
             <div className="w-full max-w-md bg-[rgba(30,30,46,0.7)] backdrop-blur-xl rounded-2xl shadow-xl p-8">
-
-                {/* Brand */}
                 <div className="text-center mb-8">
                     <h1 className="text-2xl font-bold text-white">Daftar</h1>
                     <p className="text-sm text-gray-400">Buat akun baru</p>
                 </div>
 
-                {/* Form */}
                 <form onSubmit={handleRegister} className="space-y-4">
                     <div>
                         <label className="text-sm text-gray-300">Nama Tampilan</label>
@@ -151,14 +181,12 @@ export default function RegisterPage() {
                     </button>
                 </form>
 
-                {/* Divider */}
                 <div className="flex items-center gap-2 my-6 text-gray-400 text-sm">
                     <div className="flex-grow h-px bg-white/10" />
                     <span>atau</span>
                     <div className="flex-grow h-px bg-white/10" />
                 </div>
 
-                {/* Google */}
                 <button
                     onClick={handleGoogle}
                     disabled={loading}

--- a/app/register/page.jsx
+++ b/app/register/page.jsx
@@ -1,0 +1,12 @@
+import { Suspense } from "react"
+import RegisterPageContent, { LoadingState } from "./RegisterPageContent"
+
+export const dynamic = "force-dynamic"
+
+export default function RegisterPage() {
+    return (
+        <Suspense fallback={<LoadingState />}>
+            <RegisterPageContent />
+        </Suspense>
+    )
+}

--- a/lib/supabase/client.js
+++ b/lib/supabase/client.js
@@ -1,8 +1,17 @@
 import { createBrowserClient } from "@supabase/ssr"
 
-export const createClient = () => {
-    return createBrowserClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const missingConfigError = () =>
+    new Error(
+        "Supabase belum dikonfigurasi. Pastikan NEXT_PUBLIC_SUPABASE_URL dan NEXT_PUBLIC_SUPABASE_ANON_KEY terisi."
     )
+
+export const createClient = () => {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+    if (!url || !anonKey) {
+        throw missingConfigError()
+    }
+
+    return createBrowserClient(url, anonKey)
 }

--- a/lib/supabase/server.js
+++ b/lib/supabase/server.js
@@ -1,32 +1,40 @@
 import { cookies } from "next/headers"
 import { createServerClient } from "@supabase/ssr"
 
+const missingConfigError = () =>
+    new Error(
+        "Supabase belum dikonfigurasi. Pastikan NEXT_PUBLIC_SUPABASE_URL dan NEXT_PUBLIC_SUPABASE_ANON_KEY terisi."
+    )
+
 export const createClient = () => {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+    if (!url || !anonKey) {
+        throw missingConfigError()
+    }
+
     const cookieStore = cookies()
 
-    return createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-        {
-            cookies: {
-                get(name) {
-                    return cookieStore.get(name)?.value
-                },
-                set(name, value, options) {
-                    try {
-                        cookieStore.set({ name, value, ...options })
-                    } catch {
-                        // ignore on server side
-                    }
-                },
-                remove(name, options) {
-                    try {
-                        cookieStore.set({ name, value: "", ...options })
-                    } catch {
-                        // ignore
-                    }
+    return createServerClient(url, anonKey, {
+        cookies: {
+            get(name) {
+                return cookieStore.get(name)?.value
+            },
+            set(name, value, options) {
+                try {
+                    cookieStore.set({ name, value, ...options })
+                } catch {
+                    // ignore on server side
+                }
+            },
+            remove(name, options) {
+                try {
+                    cookieStore.set({ name, value: "", ...options })
+                } catch {
+                    // ignore
                 }
             }
         }
-    )
+    })
 }


### PR DESCRIPTION
## Summary
- guard Supabase client creation on both server and browser helpers to surface missing env configuration
- wrap the global route loader and auth pages in Suspense boundaries and split login/register into client components with graceful fallbacks
- mark Supabase-dependent routes as dynamic and improve the auth callback handler's resilience and redirect logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e534a656a0832887c0a0a81982c0d1