### PR TITLE
Add modular REST API and stabilize Supabase usage

### DIFF
--- a/app/api/(rest)/entries/[id]/route.js
+++ b/app/api/(rest)/entries/[id]/route.js
@@ -1,0 +1,129 @@
+import prisma from "@/lib/prisma"
+import { successResponse, errorResponse } from "@/lib/api/response"
+import { requireUserSession } from "@/lib/auth/session"
+import { getDatabaseConfig } from "@/lib/env/server"
+
+export const dynamic = "force-dynamic"
+
+const findEntryForUser = async (supabaseUserId, entryId) =>
+    prisma.wellnessEntry.findFirst({
+        where: {
+            id: entryId,
+            user: {
+                supabaseId: supabaseUserId,
+            },
+        },
+    })
+
+export async function GET(_request, { params }) {
+    const { isConfigured, missingMessage } = getDatabaseConfig()
+    if (!isConfigured) {
+        return errorResponse(missingMessage, 503)
+    }
+
+    const { user, response } = await requireUserSession()
+
+    if (!user) {
+        return response
+    }
+
+    try {
+        const entry = await findEntryForUser(user.id, params.id)
+
+        if (!entry) {
+            return errorResponse("Aktivitas tidak ditemukan.", 404)
+        }
+
+        return successResponse("Detail aktivitas berhasil dimuat.", { entry })
+    } catch (error) {
+        console.error("Gagal mengambil detail entry:", error)
+        return errorResponse("Tidak dapat memuat aktivitas.", 500)
+    }
+}
+
+export async function PUT(request, { params }) {
+    const { isConfigured, missingMessage } = getDatabaseConfig()
+    if (!isConfigured) {
+        return errorResponse(missingMessage, 503)
+    }
+
+    const { user, response } = await requireUserSession()
+
+    if (!user) {
+        return response
+    }
+
+    let payload
+
+    try {
+        payload = await request.json()
+    } catch (error) {
+        return errorResponse("Body request tidak valid.", 400)
+    }
+
+    const title = typeof payload?.title === "string" ? payload.title.trim() : ""
+    const description =
+        typeof payload?.description === "string" ? payload.description.trim() : null
+    const mood = typeof payload?.mood === "string" ? payload.mood.trim() : null
+    const occurredAtInput = payload?.occurredAt
+    const occurredAt = occurredAtInput ? new Date(occurredAtInput) : undefined
+
+    if (!title) {
+        return errorResponse("Judul aktivitas wajib diisi.", 400)
+    }
+
+    if (occurredAt && Number.isNaN(occurredAt.getTime())) {
+        return errorResponse("Format tanggal tidak valid.", 400)
+    }
+
+    try {
+        const existing = await findEntryForUser(user.id, params.id)
+
+        if (!existing) {
+            return errorResponse("Aktivitas tidak ditemukan.", 404)
+        }
+
+        const entry = await prisma.wellnessEntry.update({
+            where: { id: existing.id },
+            data: {
+                title,
+                description,
+                mood,
+                ...(occurredAt ? { occurredAt } : {}),
+            },
+        })
+
+        return successResponse("Aktivitas berhasil diperbarui.", { entry })
+    } catch (error) {
+        console.error("Gagal memperbarui wellness entry:", error)
+        return errorResponse("Tidak dapat memperbarui aktivitas.", 500)
+    }
+}
+
+export async function DELETE(_request, { params }) {
+    const { isConfigured, missingMessage } = getDatabaseConfig()
+    if (!isConfigured) {
+        return errorResponse(missingMessage, 503)
+    }
+
+    const { user, response } = await requireUserSession()
+
+    if (!user) {
+        return response
+    }
+
+    try {
+        const existing = await findEntryForUser(user.id, params.id)
+
+        if (!existing) {
+            return errorResponse("Aktivitas tidak ditemukan.", 404)
+        }
+
+        await prisma.wellnessEntry.delete({ where: { id: existing.id } })
+
+        return successResponse("Aktivitas berhasil dihapus.")
+    } catch (error) {
+        console.error("Gagal menghapus wellness entry:", error)
+        return errorResponse("Tidak dapat menghapus aktivitas.", 500)
+    }
+}

--- a/app/api/(rest)/entries/route.js
+++ b/app/api/(rest)/entries/route.js
@@ -1,0 +1,123 @@
+import prisma from "@/lib/prisma"
+import { successResponse, errorResponse } from "@/lib/api/response"
+import { requireUserSession } from "@/lib/auth/session"
+import { getDatabaseConfig } from "@/lib/env/server"
+
+export const dynamic = "force-dynamic"
+
+export async function GET(request) {
+    const { isConfigured, missingMessage } = getDatabaseConfig()
+    if (!isConfigured) {
+        return errorResponse(missingMessage, 503)
+    }
+
+    const { user, response } = await requireUserSession()
+
+    if (!user) {
+        return response
+    }
+
+    const { searchParams } = new URL(request.url)
+    const limitParam = searchParams.get("limit")
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined
+
+    if (Number.isNaN(limit)) {
+        return errorResponse("Parameter limit harus berupa angka.", 400)
+    }
+
+    try {
+        const profile = await prisma.userProfile.findUnique({
+            where: { supabaseId: user.id },
+        })
+
+        if (!profile) {
+            return successResponse("Belum ada data untuk pengguna ini.", { entries: [] })
+        }
+
+        const entries = await prisma.wellnessEntry.findMany({
+            where: { userId: profile.id },
+            orderBy: { occurredAt: "desc" },
+            take: limit && limit > 0 ? limit : undefined,
+        })
+
+        return successResponse("Daftar aktivitas berhasil dimuat.", { entries })
+    } catch (error) {
+        console.error("Gagal mengambil wellness entry:", error)
+        return errorResponse("Tidak dapat memuat data aktivitas.", 500)
+    }
+}
+
+export async function POST(request) {
+    const { isConfigured, missingMessage } = getDatabaseConfig()
+    if (!isConfigured) {
+        return errorResponse(missingMessage, 503)
+    }
+
+    const { user, response } = await requireUserSession()
+
+    if (!user) {
+        return response
+    }
+
+    let payload = null
+
+    try {
+        payload = await request.json()
+    } catch (error) {
+        return errorResponse("Body request tidak valid.", 400)
+    }
+
+    const title = typeof payload?.title === "string" ? payload.title.trim() : ""
+    const description =
+        typeof payload?.description === "string" ? payload.description.trim() : null
+    const mood = typeof payload?.mood === "string" ? payload.mood.trim() : null
+    const occurredAtInput = payload?.occurredAt
+    const occurredAt = occurredAtInput ? new Date(occurredAtInput) : new Date()
+
+    if (!title) {
+        return errorResponse("Judul aktivitas wajib diisi.", 400)
+    }
+
+    if (Number.isNaN(occurredAt.getTime())) {
+        return errorResponse("Format tanggal tidak valid.", 400)
+    }
+
+    try {
+        const profile = await prisma.userProfile.upsert({
+            where: { supabaseId: user.id },
+            update: {
+                email: user.email ?? null,
+                displayName:
+                    user.user_metadata?.full_name ??
+                    user.user_metadata?.name ??
+                    user.user_metadata?.display_name ??
+                    null,
+            },
+            create: {
+                supabaseId: user.id,
+                email: user.email ?? null,
+                role: user.user_metadata?.role ?? "user",
+                displayName:
+                    user.user_metadata?.full_name ??
+                    user.user_metadata?.name ??
+                    user.user_metadata?.display_name ??
+                    null,
+            },
+        })
+
+        const entry = await prisma.wellnessEntry.create({
+            data: {
+                userId: profile.id,
+                title,
+                description,
+                mood,
+                occurredAt,
+            },
+        })
+
+        return successResponse("Aktivitas berhasil disimpan.", { entry }, 201)
+    } catch (error) {
+        console.error("Gagal membuat wellness entry:", error)
+        return errorResponse("Tidak dapat menyimpan aktivitas baru.", 500)
+    }
+}

--- a/app/api/(rest)/profiles/route.js
+++ b/app/api/(rest)/profiles/route.js
@@ -1,0 +1,94 @@
+import prisma from "@/lib/prisma"
+import { successResponse, errorResponse } from "@/lib/api/response"
+import { requireUserSession } from "@/lib/auth/session"
+import { getDatabaseConfig } from "@/lib/env/server"
+
+export const dynamic = "force-dynamic"
+
+const resolveDisplayName = (user) =>
+    user.user_metadata?.display_name ??
+    user.user_metadata?.full_name ??
+    user.user_metadata?.name ??
+    null
+
+export async function GET() {
+    const { isConfigured, missingMessage } = getDatabaseConfig()
+    if (!isConfigured) {
+        return errorResponse(missingMessage, 503)
+    }
+
+    const { user, response } = await requireUserSession()
+
+    if (!user) {
+        return response
+    }
+
+    try {
+        const profile = await prisma.userProfile.upsert({
+            where: { supabaseId: user.id },
+            update: {
+                email: user.email ?? null,
+                displayName: resolveDisplayName(user),
+            },
+            create: {
+                supabaseId: user.id,
+                email: user.email ?? null,
+                role: user.user_metadata?.role ?? "user",
+                displayName: resolveDisplayName(user),
+            },
+        })
+
+        return successResponse("Profil berhasil dimuat.", { profile })
+    } catch (error) {
+        console.error("Gagal memuat profil:", error)
+        return errorResponse("Tidak dapat memuat profil pengguna.", 500)
+    }
+}
+
+export async function PUT(request) {
+    const { isConfigured, missingMessage } = getDatabaseConfig()
+    if (!isConfigured) {
+        return errorResponse(missingMessage, 503)
+    }
+
+    const { user, response } = await requireUserSession()
+
+    if (!user) {
+        return response
+    }
+
+    let payload
+
+    try {
+        payload = await request.json()
+    } catch (error) {
+        return errorResponse("Body request tidak valid.", 400)
+    }
+
+    const displayName =
+        typeof payload?.displayName === "string" ? payload.displayName.trim() : ""
+
+    if (!displayName) {
+        return errorResponse("Display name wajib diisi.", 400)
+    }
+
+    try {
+        const profile = await prisma.userProfile.upsert({
+            where: { supabaseId: user.id },
+            update: {
+                displayName,
+            },
+            create: {
+                supabaseId: user.id,
+                email: user.email ?? null,
+                role: user.user_metadata?.role ?? "user",
+                displayName,
+            },
+        })
+
+        return successResponse("Profil berhasil diperbarui.", { profile })
+    } catch (error) {
+        console.error("Gagal memperbarui profil:", error)
+        return errorResponse("Tidak dapat memperbarui profil pengguna.", 500)
+    }
+}

--- a/app/api/user/sync/route.js
+++ b/app/api/user/sync/route.js
@@ -1,36 +1,18 @@
-import { NextResponse } from "next/server"
-import { createServerClient } from "@supabase/ssr"
-import { cookies } from "next/headers"
 import prisma from "@/lib/prisma"
+import { successResponse, errorResponse } from "@/lib/api/response"
+import { requireUserSession } from "@/lib/auth/session"
+import { getDatabaseConfig } from "@/lib/env/server"
 
 export async function POST() {
-    const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-        {
-            cookies: {
-                getAll: () => cookies().getAll(),
-                setAll: (arr) =>
-                    arr.forEach(({ name, value, options }) =>
-                        cookies().set(name, value, options)
-                    ),
-            },
-        }
-    )
-
-    const {
-        data: { user },
-        error,
-    } = await supabase.auth.getUser()
-
-    if (error || !user) {
-        console.error("❌ Supabase getUser error:", error)
-        return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    const { isConfigured, missingMessage } = getDatabaseConfig()
+    if (!isConfigured) {
+        return errorResponse(missingMessage, 503)
     }
 
-    // kalau user belum ada role di metadata → isi "user"
-    if (!user.user_metadata?.role) {
-        await supabase.auth.updateUser({ data: { role: "user" } })
+    const { user, response } = await requireUserSession()
+
+    if (!user) {
+        return response
     }
 
     const displayName =
@@ -39,22 +21,25 @@ export async function POST() {
         user.user_metadata?.display_name ??
         null
 
-    // upsert ke Prisma
-    await prisma.userProfile.upsert({
-        where: { supabaseId: user.id },
-        update: {
-            email: user.email ?? null,
-            role: "user",
-            displayName,
-        },
-        create: {
-            supabaseId: user.id,
-            email: user.email ?? null,
-            role: "user",
-            displayName,
-        },
-    })
+    try {
+        const profile = await prisma.userProfile.upsert({
+            where: { supabaseId: user.id },
+            update: {
+                email: user.email ?? null,
+                role: user.user_metadata?.role ?? "user",
+                displayName,
+            },
+            create: {
+                supabaseId: user.id,
+                email: user.email ?? null,
+                role: user.user_metadata?.role ?? "user",
+                displayName,
+            },
+        })
 
-    console.log("✅ Synced user:", user.email)
-    return NextResponse.json({ message: "OK" })
+        return successResponse("Profil berhasil disinkronkan.", { profile })
+    } catch (error) {
+        console.error("❌ Gagal sinkronisasi profil:", error)
+        return errorResponse("Tidak dapat menyinkronkan profil pengguna.", 500)
+    }
 }

--- a/app/auth-check/page.js
+++ b/app/auth-check/page.js
@@ -1,16 +1,19 @@
-import { createClient } from "@/lib/supabase/server"
+import { createClient, getSupabaseServerConfig } from "@/lib/supabase/server"
 
 export const dynamic = "force-dynamic"
 
 export default async function AuthCheckPage() {
-    let supabase
+    const supabase = createClient()
 
-    try {
-        supabase = createClient()
-    } catch (error) {
-        console.error("Supabase client init failed:", error)
+    if (!supabase) {
         return (
-            <pre>{JSON.stringify({ user: null, error: error.message }, null, 2)}</pre>
+            <pre>
+                {JSON.stringify(
+                    { user: null, error: getSupabaseServerConfig().missingMessage },
+                    null,
+                    2
+                )}
+            </pre>
         )
     }
 

--- a/app/auth/callback/route.js
+++ b/app/auth/callback/route.js
@@ -1,7 +1,8 @@
 // app/auth/callback/route.js
 import { NextResponse } from "next/server"
-import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
+
+import { createClientFromCookies, getSupabaseServerConfig } from "@/lib/supabase/server"
 
 export async function GET(req) {
     const requestUrl = new URL(req.url)
@@ -9,20 +10,14 @@ export async function GET(req) {
     const nextPath = requestUrl.searchParams.get("next") ?? "/home"
 
     const cookieStore = cookies()
-    const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-        {
-            cookies: {
-                getAll: () => cookieStore.getAll(),
-                setAll: (arr) => {
-                    arr.forEach(({ name, value, options }) => {
-                        cookieStore.set(name, value, options)
-                    })
-                },
-            },
-        }
-    )
+    const supabase = createClientFromCookies(cookieStore)
+
+    if (!supabase) {
+        console.warn(getSupabaseServerConfig().missingMessage)
+        const url = new URL("/login", requestUrl.origin)
+        url.searchParams.set("error", "config")
+        return NextResponse.redirect(url)
+    }
 
     if (code) {
         const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code)

--- a/app/home/page.jsx
+++ b/app/home/page.jsx
@@ -1,16 +1,14 @@
 import AuthenticatedHome from "@/components/home/AuthenticatedHome"
-import { createClient } from "@/lib/supabase/server"
+import { createClient, getSupabaseServerConfig } from "@/lib/supabase/server"
 import { redirect } from "next/navigation"
 
 export const dynamic = "force-dynamic"
 
 export default async function HomePage() {
-  let supabase
+  const supabase = createClient()
 
-  try {
-    supabase = createClient()
-  } catch (error) {
-    console.error("Supabase client init failed:", error)
+  if (!supabase) {
+    console.warn(getSupabaseServerConfig().missingMessage)
     redirect("/")
   }
 

--- a/app/login/LoginPageContent.jsx
+++ b/app/login/LoginPageContent.jsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { createClient } from "@/lib/supabase/client"
+import { createClient, getSupabaseClientConfig } from "@/lib/supabase/client"
 import { useRouteLoader } from "@/components/RouteLoader"
 
 export function LoadingState() {
@@ -18,14 +18,8 @@ export function LoadingState() {
 
 export default function LoginPageContent() {
     const router = useRouter()
-    const { client: supabase, error: configError } = useMemo(() => {
-        try {
-            return { client: createClient(), error: null }
-        } catch (error) {
-            console.error("Supabase client init failed:", error)
-            return { client: null, error }
-        }
-    }, [])
+    const supabaseConfig = getSupabaseClientConfig()
+    const supabase = useMemo(() => createClient(), [])
     const [email, setEmail] = useState("")
     const [password, setPassword] = useState("")
     const [loading, setLoading] = useState(false)
@@ -38,7 +32,7 @@ export default function LoginPageContent() {
     }, [searchParams])
 
     if (!supabase) {
-        const message = configError?.message ?? "Supabase belum dikonfigurasi."
+        const message = supabaseConfig.missingMessage
         return (
             <div className="flex min-h-screen items-center justify-center px-6 text-center text-sm text-rose-200">
                 <div className="max-w-md space-y-2 rounded-2xl border border-rose-400/30 bg-rose-950/40 p-6 backdrop-blur">

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,16 +1,14 @@
 import AuthenticatedHome from "@/components/home/AuthenticatedHome"
 import LandingPage from "@/components/home/LandingPage"
-import { createClient } from "@/lib/supabase/server"
+import { createClient, getSupabaseServerConfig } from "@/lib/supabase/server"
 
 export const dynamic = "force-dynamic"
 
 export default async function Home() {
-  let supabase
+  const supabase = createClient()
 
-  try {
-    supabase = createClient()
-  } catch (error) {
-    console.error("Supabase client init failed:", error)
+  if (!supabase) {
+    console.warn(getSupabaseServerConfig().missingMessage)
     return <LandingPage />
   }
 

--- a/app/register/RegisterPageContent.jsx
+++ b/app/register/RegisterPageContent.jsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react"
 import { useSearchParams } from "next/navigation"
-import { createClient } from "@/lib/supabase/client"
+import { createClient, getSupabaseClientConfig } from "@/lib/supabase/client"
 
 export function LoadingState() {
     return (
@@ -16,14 +16,8 @@ export function LoadingState() {
 }
 
 export default function RegisterPageContent() {
-    const { client: supabase, error: configError } = useMemo(() => {
-        try {
-            return { client: createClient(), error: null }
-        } catch (error) {
-            console.error("Supabase client init failed:", error)
-            return { client: null, error }
-        }
-    }, [])
+    const supabaseConfig = getSupabaseClientConfig()
+    const supabase = useMemo(() => createClient(), [])
     const [email, setEmail] = useState("")
     const [password, setPassword] = useState("")
     const [confirmPassword, setConfirmPassword] = useState("")
@@ -38,7 +32,7 @@ export default function RegisterPageContent() {
     }, [searchParams])
 
     if (!supabase) {
-        const message = configError?.message ?? "Supabase belum dikonfigurasi."
+        const message = supabaseConfig.missingMessage
         return (
             <div className="flex min-h-screen items-center justify-center px-6 text-center text-sm text-rose-200">
                 <div className="max-w-md space-y-2 rounded-2xl border border-rose-400/30 bg-rose-950/40 p-6 backdrop-blur">

--- a/components/LogoutButton.jsx
+++ b/components/LogoutButton.jsx
@@ -1,25 +1,40 @@
 "use client"
 
-import { createClient } from "@/lib/supabase/client"
+import { useMemo, useState } from "react"
+
+import { createClient, getSupabaseClientConfig } from "@/lib/supabase/client"
 
 export default function LogoutButton({ className = "" }) {
-    const supabase = createClient()
+    const supabase = useMemo(() => createClient(), [])
+    const { missingMessage } = getSupabaseClientConfig()
+    const [isProcessing, setIsProcessing] = useState(false)
 
     const handleLogout = async () => {
+        if (!supabase) {
+            console.warn(`Logout dibatalkan: ${missingMessage}`)
+            return
+        }
+
+        setIsProcessing(true)
         const { error } = await supabase.auth.signOut()
+        setIsProcessing(false)
+
         if (error) {
             console.error("Logout error:", error.message)
             return
         }
+
         window.location.href = "/login"
     }
 
     return (
         <button
             onClick={handleLogout}
-            className={`px-3 py-1 rounded bg-red-600 text-white hover:bg-red-700 transition ${className}`}
+            disabled={!supabase || isProcessing}
+            className={`px-3 py-1 rounded bg-red-600 text-white transition disabled:cursor-not-allowed disabled:opacity-60 hover:bg-red-700 ${className}`}
+            title={!supabase ? missingMessage : undefined}
         >
-            Logout
+            {isProcessing ? "Memproses..." : "Logout"}
         </button>
     )
 }

--- a/components/home/AuthenticatedHome.jsx
+++ b/components/home/AuthenticatedHome.jsx
@@ -1,4 +1,5 @@
 import ChatBot from "@/components/ChatBot"
+import EntryPreview from "@/components/home/EntryPreview"
 import Link from "next/link"
 import {
     AlarmClockCheck,
@@ -305,6 +306,8 @@ export default function AuthenticatedHome() {
                     Eksplor konten terbaru
                 </Link>
             </section>
+
+            <EntryPreview />
 
             <ChatBot />
         </div>

--- a/components/home/EntryPreview.jsx
+++ b/components/home/EntryPreview.jsx
@@ -1,0 +1,128 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+
+const initialState = {
+    loading: true,
+    entries: [],
+    error: null,
+}
+
+export default function EntryPreview() {
+    const [state, setState] = useState(initialState)
+
+    useEffect(() => {
+        const controller = new AbortController()
+
+        const loadEntries = async () => {
+            try {
+                const response = await fetch("/api/entries?limit=3", {
+                    signal: controller.signal,
+                })
+
+                if (!response.ok) {
+                    const payload = await response.json().catch(() => null)
+                    throw new Error(payload?.message ?? "Gagal memuat data aktivitas.")
+                }
+
+                const payload = await response.json()
+                setState({ loading: false, entries: payload.data?.entries ?? [], error: null })
+            } catch (error) {
+                if (error.name === "AbortError") return
+                setState({ loading: false, entries: [], error: error.message })
+            }
+        }
+
+        loadEntries()
+
+        return () => controller.abort()
+    }, [])
+
+    if (state.loading) {
+        return (
+            <section className="rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-inner shadow-slate-950/40">
+                <div className="flex items-center justify-between">
+                    <h2 className="text-lg font-semibold text-white">Aktivitas terbaru kamu</h2>
+                    <span className="text-xs text-slate-400">Memuat...</span>
+                </div>
+                <div className="mt-6 grid gap-3">
+                    {[...Array(3).keys()].map((index) => (
+                        <div
+                            key={index}
+                            className="animate-pulse rounded-2xl border border-slate-800/60 bg-slate-900/60 p-4"
+                        >
+                            <div className="h-4 w-40 rounded bg-slate-800" />
+                            <div className="mt-3 h-3 w-56 rounded bg-slate-800" />
+                        </div>
+                    ))}
+                </div>
+            </section>
+        )
+    }
+
+    if (state.error) {
+        return (
+            <section className="rounded-3xl border border-rose-500/40 bg-rose-950/40 p-6 text-rose-100">
+                <h2 className="text-lg font-semibold">Aktivitas terbaru</h2>
+                <p className="mt-2 text-sm text-rose-200/80">{state.error}</p>
+                <p className="mt-4 text-xs text-rose-200/70">
+                    Pastikan sudah login dan environment Supabase & database telah dikonfigurasi.
+                </p>
+            </section>
+        )
+    }
+
+    if (state.entries.length === 0) {
+        return (
+            <section className="rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 text-slate-300">
+                <div className="flex items-center justify-between">
+                    <h2 className="text-lg font-semibold text-white">Aktivitas terbaru kamu</h2>
+                    <Link href="/tambah-aktivitas" className="text-sm font-semibold text-emerald-300">
+                        Catat sekarang
+                    </Link>
+                </div>
+                <p className="mt-4 text-sm text-slate-400">
+                    Belum ada catatan aktivitas. Mulai catat makanan, olahraga, atau sesi belajar kamu untuk melihat ringkasannya di sini.
+                </p>
+            </section>
+        )
+    }
+
+    return (
+        <section className="rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-inner shadow-emerald-500/10">
+            <div className="flex items-center justify-between">
+                <h2 className="text-lg font-semibold text-white">Aktivitas terbaru kamu</h2>
+                <Link href="/kalender" className="text-sm font-semibold text-emerald-300">
+                    Lihat semua
+                </Link>
+            </div>
+            <div className="mt-6 grid gap-3">
+                {state.entries.map((entry) => (
+                    <article
+                        key={entry.id}
+                        className="rounded-2xl border border-slate-800/60 bg-slate-900/60 p-4 transition hover:border-emerald-400/40 hover:bg-slate-900"
+                    >
+                        <div className="flex items-center justify-between gap-4">
+                            <h3 className="text-base font-semibold text-white">{entry.title}</h3>
+                            {entry.mood && (
+                                <span className="rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-200">
+                                    {entry.mood}
+                                </span>
+                            )}
+                        </div>
+                        {entry.description && (
+                            <p className="mt-2 text-sm text-slate-300">{entry.description}</p>
+                        )}
+                        <time className="mt-3 block text-xs text-slate-500">
+                            {new Date(entry.occurredAt ?? entry.createdAt).toLocaleString("id-ID", {
+                                dateStyle: "medium",
+                                timeStyle: "short",
+                            })}
+                        </time>
+                    </article>
+                ))}
+            </div>
+        </section>
+    )
+}

--- a/lib/api/response.js
+++ b/lib/api/response.js
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server"
+
+export const successResponse = (message, data = null, status = 200) =>
+    NextResponse.json({ status: "success", message, data }, { status })
+
+export const errorResponse = (message, status = 500, data = null) =>
+    NextResponse.json({ status: "error", message, data }, { status })

--- a/lib/auth/session.js
+++ b/lib/auth/session.js
@@ -1,0 +1,26 @@
+import { cookies } from "next/headers"
+
+import { createClientFromCookies, getSupabaseServerConfig } from "@/lib/supabase/server"
+import { errorResponse } from "@/lib/api/response"
+
+export const requireUserSession = async () => {
+    const cookieStore = cookies()
+    const supabase = createClientFromCookies(cookieStore)
+
+    if (!supabase) {
+        const { missingMessage } = getSupabaseServerConfig()
+        return { user: null, response: errorResponse(missingMessage, 503) }
+    }
+
+    const {
+        data: { user },
+        error,
+    } = await supabase.auth.getUser()
+
+    if (error || !user) {
+        const message = error?.message ?? "Sesi tidak valid. Silakan login ulang."
+        return { user: null, response: errorResponse(message, 401) }
+    }
+
+    return { user, supabase }
+}

--- a/lib/env/public.js
+++ b/lib/env/public.js
@@ -1,0 +1,26 @@
+const missingSupabaseMessage =
+    "Supabase belum dikonfigurasi. NEXT_PUBLIC_SUPABASE_URL dan NEXT_PUBLIC_SUPABASE_ANON_KEY wajib diisi."
+
+export const getPublicSupabaseConfig = () => {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ""
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? ""
+    const runtimeEnv = process.env.NEXT_PUBLIC_ENV ?? process.env.NODE_ENV ?? "development"
+
+    return {
+        url,
+        anonKey,
+        runtimeEnv,
+        isConfigured: Boolean(url && anonKey),
+        missingMessage: missingSupabaseMessage,
+    }
+}
+
+export const warnMissingSupabaseConfig = (() => {
+    let hasWarned = false
+    return () => {
+        const { missingMessage, isConfigured } = getPublicSupabaseConfig()
+        if (isConfigured || hasWarned) return
+        hasWarned = true
+        console.warn(`⚠️ ${missingMessage}`)
+    }
+})()

--- a/lib/env/server.js
+++ b/lib/env/server.js
@@ -1,0 +1,26 @@
+const missingDatabaseMessage =
+    "Database belum dikonfigurasi. Pastikan DATABASE_URL tersedia di environment."
+const missingServiceKeyMessage =
+    "Service role Supabase belum dikonfigurasi. Tambahkan SUPABASE_SERVICE_ROLE_KEY bila perlu akses admin."
+
+export const getDatabaseConfig = () => {
+    const url = process.env.DATABASE_URL ?? ""
+    const directUrl = process.env.DIRECT_URL ?? ""
+
+    return {
+        url,
+        directUrl,
+        isConfigured: Boolean(url),
+        missingMessage: missingDatabaseMessage,
+    }
+}
+
+export const getSupabaseServiceRoleConfig = () => {
+    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? ""
+
+    return {
+        serviceRoleKey,
+        isConfigured: Boolean(serviceRoleKey),
+        missingMessage: missingServiceKeyMessage,
+    }
+}

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,7 +1,15 @@
 import { PrismaClient } from "@prisma/client"
 
 const globalForPrisma = globalThis
-const prisma = globalForPrisma.prisma || new PrismaClient()
-if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma
+
+const prisma =
+    globalForPrisma.prisma ||
+    new PrismaClient({
+        log: process.env.NODE_ENV === "development" ? ["error", "warn"] : ["error"],
+    })
+
+if (process.env.NODE_ENV !== "production") {
+    globalForPrisma.prisma = prisma
+}
 
 export default prisma

--- a/lib/supabase/client.js
+++ b/lib/supabase/client.js
@@ -1,17 +1,16 @@
 import { createBrowserClient } from "@supabase/ssr"
 
-const missingConfigError = () =>
-    new Error(
-        "Supabase belum dikonfigurasi. Pastikan NEXT_PUBLIC_SUPABASE_URL dan NEXT_PUBLIC_SUPABASE_ANON_KEY terisi."
-    )
+import { getPublicSupabaseConfig, warnMissingSupabaseConfig } from "@/lib/env/public"
 
 export const createClient = () => {
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    const { url, anonKey, isConfigured } = getPublicSupabaseConfig()
 
-    if (!url || !anonKey) {
-        throw missingConfigError()
+    if (!isConfigured) {
+        warnMissingSupabaseConfig()
+        return null
     }
 
     return createBrowserClient(url, anonKey)
 }
+
+export const getSupabaseClientConfig = getPublicSupabaseConfig

--- a/lib/supabase/server.js
+++ b/lib/supabase/server.js
@@ -1,40 +1,51 @@
-import { cookies } from "next/headers"
 import { createServerClient } from "@supabase/ssr"
+import { cookies as nextCookies } from "next/headers"
 
-const missingConfigError = () =>
-    new Error(
-        "Supabase belum dikonfigurasi. Pastikan NEXT_PUBLIC_SUPABASE_URL dan NEXT_PUBLIC_SUPABASE_ANON_KEY terisi."
-    )
+import { getPublicSupabaseConfig, warnMissingSupabaseConfig } from "@/lib/env/public"
 
-export const createClient = () => {
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const resolveCookieValue = (cookie) => {
+    if (!cookie) return undefined
+    if (typeof cookie === "string") return cookie
+    return cookie.value
+}
 
-    if (!url || !anonKey) {
-        throw missingConfigError()
+const instantiateServerClient = (cookieStore) => {
+    const { url, anonKey, isConfigured } = getPublicSupabaseConfig()
+
+    if (!isConfigured) {
+        warnMissingSupabaseConfig()
+        return null
     }
 
-    const cookieStore = cookies()
+    const store = cookieStore ?? nextCookies()
 
     return createServerClient(url, anonKey, {
         cookies: {
             get(name) {
-                return cookieStore.get(name)?.value
+                return resolveCookieValue(store.get(name))
             },
             set(name, value, options) {
                 try {
-                    cookieStore.set({ name, value, ...options })
-                } catch {
-                    // ignore on server side
+                    store.set?.({ name, value, ...options })
+                } catch (error) {
+                    if (process.env.NODE_ENV === "development") {
+                        console.warn("Tidak bisa menyetel cookie Supabase di konteks ini:", error?.message)
+                    }
                 }
             },
             remove(name, options) {
                 try {
-                    cookieStore.set({ name, value: "", ...options })
-                } catch {
-                    // ignore
+                    store.set?.({ name, value: "", ...options })
+                } catch (error) {
+                    if (process.env.NODE_ENV === "development") {
+                        console.warn("Tidak bisa menghapus cookie Supabase di konteks ini:", error?.message)
+                    }
                 }
-            }
-        }
+            },
+        },
     })
 }
+
+export const createClient = () => instantiateServerClient()
+export const createClientFromCookies = (cookieStore) => instantiateServerClient(cookieStore)
+export const getSupabaseServerConfig = getPublicSupabaseConfig

--- a/middleware.js
+++ b/middleware.js
@@ -1,35 +1,23 @@
-// middleware.js
 import { NextResponse } from "next/server"
-import { createServerClient } from "@supabase/ssr"
+import { createMiddlewareClient } from "@supabase/ssr"
+
+import { getPublicSupabaseConfig, warnMissingSupabaseConfig } from "@/lib/env/public"
 
 const isDev = process.env.NODE_ENV === "development"
-const hasSupabaseConfig = Boolean(
-    process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-)
 
 export async function middleware(req) {
     const res = NextResponse.next()
+    const { url, anonKey, isConfigured } = getPublicSupabaseConfig()
 
-    if (!hasSupabaseConfig) {
+    if (!isConfigured) {
+        warnMissingSupabaseConfig()
         if (isDev) {
             console.warn("⚠️ Supabase env belum di-set, middleware melewati proteksi auth.")
         }
         return res
     }
 
-    const supabase = createServerClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-        {
-            cookies: {
-                getAll: () => req.cookies.getAll(),
-                setAll: (cookies) => {
-                    cookies.forEach(({ name, value }) => req.cookies.set(name, value))
-                    res.cookies.set(cookies)
-                },
-            },
-        }
-    )
+    const supabase = createMiddlewareClient({ req, res }, { supabaseUrl: url, supabaseKey: anonKey })
 
     const {
         data: { user },
@@ -42,33 +30,33 @@ export async function middleware(req) {
         console.log("🔍 Error:", error)
     }
 
+    if (error && isDev) {
+        console.warn("⚠️ Supabase middleware warning:", error.message)
+    }
+
     const publicPaths = ["/", "/login", "/register"]
     const authOnlyPaths = ["/login", "/register"]
     const isAuthCallback = req.nextUrl.pathname === "/auth/callback"
 
-    // 1️⃣ kalau BELUM login → tendang ke /login (kecuali di path /login & /register)
     if (!user && !publicPaths.includes(req.nextUrl.pathname) && !isAuthCallback) {
-        if (isDev) console.log("⚠️ Redirecting: Not logged in")
         const redirectUrl = req.nextUrl.clone()
         redirectUrl.pathname = "/login"
+        if (req.nextUrl.pathname !== "/login") {
+            redirectUrl.searchParams.set("next", req.nextUrl.pathname)
+        }
         return NextResponse.redirect(redirectUrl)
     }
 
-    // 2️⃣ kalau SUDAH login → jangan bisa buka halaman auth atau landing
     if (user && (authOnlyPaths.includes(req.nextUrl.pathname) || req.nextUrl.pathname === "/")) {
-        if (isDev) console.log("⚠️ Redirecting: Already logged in")
         const redirectUrl = req.nextUrl.clone()
         redirectUrl.pathname = "/home"
         return NextResponse.redirect(redirectUrl)
     }
 
-    // 3️⃣ kalau admin path tapi role bukan admin → tendang ke root
     if (user) {
         const role = user.user_metadata?.role || "user"
-        if (isDev) console.log("✅ Role:", role)
 
         if (req.nextUrl.pathname.startsWith("/admin") && role !== "admin") {
-            if (isDev) console.log("⛔ Access denied: not admin")
             const redirectUrl = req.nextUrl.clone()
             redirectUrl.pathname = "/home"
             return NextResponse.redirect(redirectUrl)
@@ -80,7 +68,6 @@ export async function middleware(req) {
 
 export const config = {
     matcher: [
-        // cek hanya untuk route aplikasi
         "/((?!_next/static|_next/image|favicon.ico|Logo.png|api/public).*)",
     ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,13 @@
         "postcss": "8.4.38",
         "prisma": "^6.16.3",
         "tailwindcss": "3.4.10"
+      },
+      "scripts": {
+        "db:generate": "prisma generate",
+        "db:seed": "prisma db seed"
+      },
+      "prisma": {
+        "seed": "node prisma/seed.js"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "postinstall": "tailwindcss -v || exit 0"
+    "postinstall": "tailwindcss -v || exit 0",
+    "db:generate": "prisma generate",
+    "db:seed": "prisma db seed"
   },
   "dependencies": {
     "@prisma/client": "^6.16.3",
@@ -29,5 +31,8 @@
     "postcss": "8.4.38",
     "prisma": "^6.16.3",
     "tailwindcss": "3.4.10"
+  },
+  "prisma": {
+    "seed": "node prisma/seed.js"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,4 +16,20 @@ model UserProfile {
   displayName String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+  entries     WellnessEntry[]
+}
+
+model WellnessEntry {
+  id          String   @id @default(uuid())
+  userId      String
+  title       String
+  description String?
+  mood        String?
+  occurredAt  DateTime @default(now())
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  user UserProfile @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,58 @@
+import { PrismaClient } from "@prisma/client"
+
+const prisma = new PrismaClient()
+
+async function main() {
+    const seedUser = await prisma.userProfile.upsert({
+        where: { supabaseId: "00000000-0000-0000-0000-000000000000" },
+        update: {
+            displayName: "Contoh Pengguna",
+            email: "user@example.com",
+        },
+        create: {
+            supabaseId: "00000000-0000-0000-0000-000000000000",
+            displayName: "Contoh Pengguna",
+            email: "user@example.com",
+            role: "user",
+        },
+    })
+
+    await prisma.wellnessEntry.deleteMany({ where: { userId: seedUser.id } })
+
+    const sampleEntries = [
+        {
+            title: "Sarapan oatmeal hemat",
+            description: "Oat instan + susu UHT + pisang, siap dalam 6 menit.",
+            mood: "energized",
+            occurredAt: new Date(),
+            userId: seedUser.id,
+        },
+        {
+            title: "Workout kardio ringan",
+            description: "Jogging 20 menit keliling komplek kos.",
+            mood: "motivated",
+            occurredAt: new Date(Date.now() - 1000 * 60 * 60 * 6),
+            userId: seedUser.id,
+        },
+        {
+            title: "Belajar sesi malam",
+            description: "Review materi kalkulus selama 45 menit.",
+            mood: "focused",
+            occurredAt: new Date(Date.now() - 1000 * 60 * 60 * 24),
+            userId: seedUser.id,
+        },
+    ]
+
+    await prisma.wellnessEntry.createMany({
+        data: sampleEntries,
+    })
+}
+
+main()
+    .catch((error) => {
+        console.error("Gagal menjalankan seed Prisma:", error)
+        process.exit(1)
+    })
+    .finally(async () => {
+        await prisma.$disconnect()
+    })


### PR DESCRIPTION
## Summary
- add environment helpers and update Supabase client/server consumers to fail gracefully when configuration is missing
- introduce reusable API/session utilities, Prisma seed data, and REST endpoints for user profiles and wellness entries
- surface entry previews on the authenticated home dashboard and expand project scripts for Prisma workflows

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5b37545e88328baeabf9f0e9b3e52