### PR TITLE
Fix missing Supabase config import in middleware

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server"
 import * as SupabaseSSR from "@supabase/ssr"
+import { getPublicSupabaseConfig, warnMissingSupabaseConfig } from "@/lib/env/public"
 
 const isDev = process.env.NODE_ENV === "development"
 


### PR DESCRIPTION
## Summary
- import the Supabase configuration helpers into the middleware to resolve runtime reference errors

## Testing
- npm run lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e7e03a27608328881d500ea8f49ab4