### PR TITLE
Improve mood tracker feedback and daily logging

### DIFF
--- a/app/api/mood/route.js
+++ b/app/api/mood/route.js
@@ -4,6 +4,99 @@ import { requireUserSession } from "@/lib/auth/session"
 import { getDatabaseConfig } from "@/lib/env/server"
 import { ensureProfile } from "@/lib/profile"
 
+function getTodayRange() {
+  const start = new Date()
+  start.setHours(0, 0, 0, 0)
+
+  const end = new Date()
+  end.setHours(23, 59, 59, 999)
+
+  return { start, end }
+}
+
+async function getTodayMoodLog(profileId) {
+  const { start, end } = getTodayRange()
+
+  return prisma.moodLog.findFirst({
+    where: {
+      userId: profileId,
+      createdAt: {
+        gte: start,
+        lte: end,
+      },
+    },
+    orderBy: { createdAt: "desc" },
+  })
+}
+
+async function upsertWellnessEntry(profileId, mood, note) {
+  const { start, end } = getTodayRange()
+
+  const existingEntry = await prisma.wellnessEntry.findFirst({
+    where: {
+      userId: profileId,
+      occurredAt: {
+        gte: start,
+        lte: end,
+      },
+      title: {
+        startsWith: "Catatan mood",
+      },
+    },
+    orderBy: { occurredAt: "desc" },
+  })
+
+  if (existingEntry) {
+    await prisma.wellnessEntry.update({
+      where: { id: existingEntry.id },
+      data: {
+        title: `Catatan mood: ${mood}`,
+        description: note,
+        mood,
+        occurredAt: new Date(),
+      },
+    })
+    return existingEntry.id
+  }
+
+  const entry = await prisma.wellnessEntry.create({
+    data: {
+      userId: profileId,
+      title: `Catatan mood: ${mood}`,
+      description: note,
+      mood,
+    },
+  })
+
+  return entry.id
+}
+
+export async function GET() {
+  const { isConfigured, missingMessage } = getDatabaseConfig()
+  if (!isConfigured) {
+    return errorResponse(missingMessage, 503)
+  }
+
+  const { user, response } = await requireUserSession()
+  if (!user) {
+    return response
+  }
+
+  try {
+    const profile = await ensureProfile(user)
+    const moodLog = await getTodayMoodLog(profile.id)
+
+    if (!moodLog) {
+      return successResponse("Belum ada mood yang dicatat hari ini.", { moodLog: null })
+    }
+
+    return successResponse("Mood hari ini ditemukan.", { moodLog })
+  } catch (error) {
+    console.error("Gagal mengambil mood hari ini:", error)
+    return errorResponse("Tidak dapat mengambil mood hari ini.")
+  }
+}
+
 export async function POST(request) {
   const { isConfigured, missingMessage } = getDatabaseConfig()
   if (!isConfigured) {
@@ -32,6 +125,22 @@ export async function POST(request) {
   try {
     const profile = await ensureProfile(user)
 
+    const existingMood = await getTodayMoodLog(profile.id)
+
+    if (existingMood) {
+      const updatedMood = await prisma.moodLog.update({
+        where: { id: existingMood.id },
+        data: {
+          mood,
+          note,
+        },
+      })
+
+      await upsertWellnessEntry(profile.id, mood, note)
+
+      return successResponse("Mood harian diperbarui.", { moodLog: updatedMood })
+    }
+
     const moodLog = await prisma.moodLog.create({
       data: {
         userId: profile.id,
@@ -40,14 +149,7 @@ export async function POST(request) {
       },
     })
 
-    await prisma.wellnessEntry.create({
-      data: {
-        userId: profile.id,
-        title: `Catatan mood: ${mood}`,
-        description: note,
-        mood,
-      },
-    })
+    await upsertWellnessEntry(profile.id, mood, note)
 
     return successResponse("Mood berhasil dicatat.", { moodLog })
   } catch (error) {

--- a/app/olahraga/page.jsx
+++ b/app/olahraga/page.jsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { Brain, Dumbbell, HeartPulse, MoonStar, Smile, Sparkles, SunMedium, Timer } from "lucide-react";
+import { Brain, Check, Dumbbell, HeartPulse, MoonStar, Smile, Sparkles, SunMedium, Timer } from "lucide-react";
 import PageHero from "@/components/ui/PageHero";
 import { useAsyncLoader } from "@/components/RouteLoader";
 
@@ -64,6 +64,9 @@ export default function Olahraga() {
   const [message, setMessage] = useState("");
   const [toast, setToast] = useState("");
   const [recommendedWorkout, setRecommendedWorkout] = useState(null);
+  const [todayMood, setTodayMood] = useState(null);
+  const [isLoadingTodayMood, setIsLoadingTodayMood] = useState(true);
+  const [isSavingMood, setIsSavingMood] = useState(false);
   const { track } = useAsyncLoader();
 
   useEffect(() => {
@@ -80,6 +83,33 @@ export default function Olahraga() {
     loadWorkouts();
   }, [track]);
 
+  useEffect(() => {
+    async function loadTodayMood() {
+      try {
+        setIsLoadingTodayMood(true);
+        const response = await track(() => fetch("/api/mood"));
+        const payload = await response.json().catch(() => null);
+        if (!response.ok || payload?.status !== "success") {
+          return;
+        }
+
+        const moodLog = payload?.data?.moodLog;
+        if (moodLog) {
+          setTodayMood(moodLog);
+          setMood(moodLog.mood);
+          setMessage(MOOD_SOLUTIONS[moodLog.mood] || "");
+          setRecommendedWorkout(WORKOUT_SUGGESTIONS[moodLog.mood] || null);
+        }
+      } catch (error) {
+        console.error("Gagal mengambil mood hari ini", error);
+      } finally {
+        setIsLoadingTodayMood(false);
+      }
+    }
+
+    loadTodayMood();
+  }, [track]);
+
   async function submitMood() {
     if (!mood) {
       setToast("Silakan pilih mood dulu!");
@@ -87,6 +117,7 @@ export default function Olahraga() {
       return;
     }
 
+    setIsSavingMood(true);
     try {
       const response = await track(() =>
         fetch("/api/mood", {
@@ -101,18 +132,39 @@ export default function Olahraga() {
         setTimeout(() => setToast(""), 2500);
         return;
       }
+
+      const savedMoodLog = payload?.data?.moodLog;
+      if (savedMoodLog) {
+        setTodayMood(savedMoodLog);
+        setMood(savedMoodLog.mood);
+      }
     } catch (error) {
       console.error("Gagal menyimpan mood", error);
       setToast("Gagal menyimpan mood.");
       setTimeout(() => setToast(""), 2500);
       return;
+    } finally {
+      setIsSavingMood(false);
     }
 
     setMessage(MOOD_SOLUTIONS[mood] || "");
     setRecommendedWorkout(WORKOUT_SUGGESTIONS[mood] || null);
-    setMood("");
-    setToast("Rekaman anda sudah di simpan !");
+    setToast(todayMood ? "Mood harian kamu diperbarui." : "Mood harian kamu sudah disimpan!");
     setTimeout(() => setToast(""), 2500);
+  }
+
+  const hasMoodToday = Boolean(todayMood);
+
+  function formatMoodTimestamp(value) {
+    if (!value) return "";
+    try {
+      return new Intl.DateTimeFormat("id-ID", {
+        dateStyle: "long",
+        timeStyle: "short",
+      }).format(new Date(value));
+    } catch (error) {
+      return "";
+    }
   }
 
   return (
@@ -229,19 +281,44 @@ export default function Olahraga() {
             </div>
           </div>
 
+          {hasMoodToday && (
+            <div className="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 p-4 text-sm text-emerald-100">
+              <p className="font-semibold text-emerald-50">Mood kamu hari ini sudah tercatat.</p>
+              <p className="mt-1 text-emerald-100/80">
+                <span className="font-semibold">{todayMood?.mood}</span>
+                {todayMood?.createdAt && (
+                  <span className="ml-1 text-xs text-emerald-100/70">
+                    (dicatat {formatMoodTimestamp(todayMood.createdAt)})
+                  </span>
+                )}
+              </p>
+              <p className="mt-2 text-xs text-emerald-100/70">
+                Kamu masih bisa memperbarui mood bila perasaanmu berubah hari ini.
+              </p>
+            </div>
+          )}
+
           <div className="grid gap-3 sm:grid-cols-2">
             {MOOD_CHOICES.map(({ value, label, hint, icon: Icon }) => (
               <button
                 key={value}
                 onClick={() => {
                   setMood(value);
+                  setMessage("");
+                  setRecommendedWorkout(null);
                 }}
-                className={`rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4 text-left transition duration-200 hover:border-emerald-400/40 hover:bg-slate-900/60 ${
+                aria-pressed={mood === value}
+                className={`relative rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4 text-left transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-400/70 ${
                   mood === value
-                    ? "border-emerald-400/60 bg-emerald-500/10 text-white shadow-inner shadow-emerald-500/30"
-                    : "text-slate-100"
+                    ? "border-emerald-400/80 bg-emerald-500/15 text-white shadow-[0_10px_40px_-25px_rgba(16,185,129,0.9)]"
+                    : "text-slate-100 hover:border-emerald-400/40 hover:bg-slate-900/60"
                 }`}
               >
+                {mood === value && (
+                  <span className="absolute right-4 top-4 inline-flex items-center gap-1 rounded-full bg-emerald-500/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-emerald-100">
+                    <Check className="h-4 w-4" aria-hidden="true" />Dipilih
+                  </span>
+                )}
                 <div className="flex items-start gap-3">
                   <div className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-emerald-500/10 text-emerald-200">
                     <Icon className="h-5 w-5" aria-hidden="true" />
@@ -255,8 +332,12 @@ export default function Olahraga() {
             ))}
           </div>
 
-          <button onClick={submitMood} className="btn btn-primary w-full sm:w-auto">
-            Simpan mood
+          <button
+            onClick={submitMood}
+            className="btn btn-primary w-full sm:w-auto"
+            disabled={isLoadingTodayMood || isSavingMood}
+          >
+            {hasMoodToday ? "Perbarui mood" : "Simpan mood"}
           </button>
 
           {message && (


### PR DESCRIPTION
## Summary
- add helper utilities in the mood API to fetch and reuse the current day range
- expose a GET handler and update POST to upsert the current day mood alongside the related wellness entry
- refresh the olahraga mood tracker UI with clearer selection states, daily status messaging, and save button loading guards

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68ebbf8e246c8328bf3a424cb755c989